### PR TITLE
Modified type of variables float64 to int32 in Rect.msg

### DIFF
--- a/msg/Rect.msg
+++ b/msg/Rect.msg
@@ -1,6 +1,6 @@
 # opencv Rect data type, x-y is center point
-float64 x
-float64 y
-float64 width
-float64 height
+int32 x
+int32 y
+int32 width
+int32 height
 


### PR DESCRIPTION
OpenCv's types of Rect.x, Rect.y, Rect.height, Rect.width are int.
so, we should use int32.
http://docs.opencv.org/2.4/modules/core/doc/basic_structures.html

> For your convenience, the Rect_<> alias is available:
> typedef Rect_<int> Rect;
