### PR TITLE
proposal for chaning nodlet pkg/type name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,28 +96,28 @@ endmacro()
 
 # https://github.com/Itseez/opencv/blob/2.4/samples/cpp/tutorial_code
 # ImgTrans
-opencv_apps_add_nodelet(edge_detection edge_detection/edge_detection src/nodelet/edge_detection_nodelet.cpp)
-opencv_apps_add_nodelet(hough_lines hough_lines/hough_lines src/nodelet/hough_lines_nodelet.cpp)
-opencv_apps_add_nodelet(hough_circles hough_circles/hough_circles src/nodelet/hough_circles_nodelet.cpp)
+opencv_apps_add_nodelet(edge_detection opencv_apps/edge_detection src/nodelet/edge_detection_nodelet.cpp)
+opencv_apps_add_nodelet(hough_lines opencv_apps/hough_lines src/nodelet/hough_lines_nodelet.cpp)
+opencv_apps_add_nodelet(hough_circles opencv_apps/hough_circles src/nodelet/hough_circles_nodelet.cpp)
 # ShapeDescriptors
-opencv_apps_add_nodelet(find_contours find_contours/find_contours src/nodelet/find_contours_nodelet.cpp)
-opencv_apps_add_nodelet(convex_hull convex_hull/convex_hull src/nodelet/convex_hull_nodelet.cpp)
-opencv_apps_add_nodelet(general_contours general_contours/general_contours src/nodelet/general_contours_nodelet.cpp)
-opencv_apps_add_nodelet(contour_moments contour_moments/contour_moments src/nodelet/contour_moments_nodelet.cpp)
+opencv_apps_add_nodelet(find_contours opencv_apps/find_contours src/nodelet/find_contours_nodelet.cpp)
+opencv_apps_add_nodelet(convex_hull opencv_apps/convex_hull src/nodelet/convex_hull_nodelet.cpp)
+opencv_apps_add_nodelet(general_contours opencv_apps/general_contours src/nodelet/general_contours_nodelet.cpp)
+opencv_apps_add_nodelet(contour_moments opencv_apps/contour_moments src/nodelet/contour_moments_nodelet.cpp)
 # objectDetection
-opencv_apps_add_nodelet(face_detection face_detection/face_detection src/nodelet/face_detection_nodelet.cpp)
-opencv_apps_add_nodelet(people_detect people_detect/people_detect src/nodelet/people_detect_nodelet.cpp)
+opencv_apps_add_nodelet(face_detection opencv_apps/face_detection src/nodelet/face_detection_nodelet.cpp)
+opencv_apps_add_nodelet(people_detect opencv_apps/people_detect src/nodelet/people_detect_nodelet.cpp)
   # bgfg_gmg.cpp
   # bgfg_segm.cpp
   # calibration.cpp
 # TrackingMotion
-opencv_apps_add_nodelet(goodfeature_track goodfeature_track/goodfeature_track src/nodelet/goodfeature_track_nodelet.cpp)
+opencv_apps_add_nodelet(goodfeature_track opencv_apps/goodfeature_track src/nodelet/goodfeature_track_nodelet.cpp)
 # Samples
-opencv_apps_add_nodelet(camshift camshift/camshift src/nodelet/camshift_nodelet.cpp)
-opencv_apps_add_nodelet(simple_example simple_example/simple_example src/nodelet/simple_example_nodelet.cpp)
-opencv_apps_add_nodelet(simple_compressed_example simple_compressed_example/simple_compressed_example src/nodelet/simple_compressed_example_nodelet.cpp)
+opencv_apps_add_nodelet(camshift opencv_apps/camshift src/nodelet/camshift_nodelet.cpp)
+opencv_apps_add_nodelet(simple_example opencv_apps/simple_example src/nodelet/simple_example_nodelet.cpp)
+opencv_apps_add_nodelet(simple_compressed_example opencv_apps/simple_compressed_example src/nodelet/simple_compressed_example_nodelet.cpp)
 # Optical Flow
-opencv_apps_add_nodelet(fback_flow fback_flow/fback_flow src/nodelet/fback_flow_nodelet.cpp)
+opencv_apps_add_nodelet(fback_flow opencv_apps/fback_flow src/nodelet/fback_flow_nodelet.cpp)
   # fback.cpp
   # hybridtrackingsample.cpp
   # image_sequence.cpp
@@ -125,24 +125,24 @@ opencv_apps_add_nodelet(fback_flow fback_flow/fback_flow src/nodelet/fback_flow_
   # laplace.cpp
   # linemod.cpp
   # lkdemo.cpp
-opencv_apps_add_nodelet(lk_flow lk_flow/lk_flow src/nodelet/lk_flow_nodelet.cpp)
+opencv_apps_add_nodelet(lk_flow opencv_apps/lk_flow src/nodelet/lk_flow_nodelet.cpp)
 # Others
-opencv_apps_add_nodelet(phase_corr phase_corr/phase_corr src/nodelet/phase_corr_nodelet.cpp)
+opencv_apps_add_nodelet(phase_corr opencv_apps/phase_corr src/nodelet/phase_corr_nodelet.cpp)
   # phase_corr.cpp
   # retinaDemo.cpp
   # segment_objects.cpp
 # Segmentation
-opencv_apps_add_nodelet(segment_objects segment_objects/segment_objects src/nodelet/segment_objects_nodelet.cpp)
+opencv_apps_add_nodelet(segment_objects opencv_apps/segment_objects src/nodelet/segment_objects_nodelet.cpp)
   # select3dobj.cpp
 # simple flow requires opencv-contrib https://github.com/ros-perception/vision_opencv/issues/108
 if(OPENCV_HAVE_OPTFLOW)
-  opencv_apps_add_nodelet(simple_flow simple_flow/simple_flow src/nodelet/simple_flow_nodelet.cpp)
+  opencv_apps_add_nodelet(simple_flow opencv_apps/simple_flow src/nodelet/simple_flow_nodelet.cpp)
 endif()
   # starter_video.cpp
   # videocapture_pvapi.cpp
   # video_dmtx.cpp
   # video_homography.cpp
-opencv_apps_add_nodelet(watershed_segmentation watershed_segmentation/watershed_segmentation src/nodelet/watershed_segmentation_nodelet.cpp)
+opencv_apps_add_nodelet(watershed_segmentation opencv_apps/watershed_segmentation src/nodelet/watershed_segmentation_nodelet.cpp)
 
 add_library(${PROJECT_NAME} SHARED
   src/nodelet/nodelet.cpp

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,78 +1,78 @@
 <library path="lib/libopencv_apps">
 
-  <class name="edge_detection/edge_detection" type="edge_detection::EdgeDetectionNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/edge_detection" type="edge_detection::EdgeDetectionNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find edges</description>
   </class>
 
-  <class name="hough_lines/hough_lines" type="hough_lines::HoughLinesNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/hough_lines" type="hough_lines::HoughLinesNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find lines</description>
   </class>
 
-  <class name="hough_circles/hough_circles" type="hough_circles::HoughCirclesNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/hough_circles" type="hough_circles::HoughCirclesNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find circles</description>
   </class>
 
-  <class name="find_contours/find_contours" type="find_contours::FindContoursNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/find_contours" type="find_contours::FindContoursNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find contours</description>
   </class>
 
-  <class name="convex_hull/convex_hull" type="convex_hull::ConvexHullNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/convex_hull" type="convex_hull::ConvexHullNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find convex hulls</description>
   </class>
 
-  <class name="general_contours/general_contours" type="general_contours::GeneralContoursNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/general_contours" type="general_contours::GeneralContoursNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to creating bounding boxes and circles for contours</description>
   </class>
 
-  <class name="contour_moments/contour_moments" type="contour_moments::ContourMomentsNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/contour_moments" type="contour_moments::ContourMomentsNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find image moments</description>
   </class>
 
-  <class name="face_detection/face_detection" type="face_detection::FaceDetectionNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/face_detection" type="face_detection::FaceDetectionNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to find faces</description>
   </class>
 
-  <class name="goodfeature_track/goodfeature_track" type="goodfeature_track::GoodfeatureTrackNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/goodfeature_track" type="goodfeature_track::GoodfeatureTrackNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet for detecting corners using Shi-Tomasi method</description>
   </class>
 
-  <class name="camshift/camshift" type="camshift::CamShiftNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/camshift" type="camshift::CamShiftNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to show mean-shift based tracking</description>
   </class>
 
-  <class name="fback_flow/fback_flow" type="fback_flow::FBackFlowNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/fback_flow" type="fback_flow::FBackFlowNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to demonstrates dense optical flow algorithm by Gunnar Farneback</description>
   </class>
 
-  <class name="lk_flow/lk_flow" type="lk_flow::LKFlowNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/lk_flow" type="lk_flow::LKFlowNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to calculate Lukas-Kanade optical flow</description>
   </class>
 
-  <class name="people_detect/people_detect" type="people_detect::PeopleDetectNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/people_detect" type="people_detect::PeopleDetectNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to demonstrate the use of the HoG descriptor</description>
   </class>
 
-  <class name="phase_corr/phase_corr" type="phase_corr::PhaseCorrNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/phase_corr" type="phase_corr::PhaseCorrNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to demonstrate the use of phaseCorrelate</description>
   </class>
 
-  <class name="segment_objects/segment_objects" type="segment_objects::SegmentObjectsNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/segment_objects" type="segment_objects::SegmentObjectsNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to demonstrate a simple method of connected components clean up of background subtraction</description>
   </class>
 
-  <class name="simple_flow/simple_flow" type="simple_flow::SimpleFlowNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/simple_flow" type="simple_flow::SimpleFlowNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet of SimpleFlow optical flow algorithm</description>
   </class>
   
- <class name="simple_example/simple_example" type="simple_example::SimpleExampleNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/simple_example" type="simple_example::SimpleExampleNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet of Simple Example from wiki</description>
   </class>
   
-   <class name="simple_compressed_example/simple_compressed_example" type="simple_compressed_example::SimpleCompressedExampleNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/simple_compressed_example" type="simple_compressed_example::SimpleCompressedExampleNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet of Simple Example from wiki</description>
   </class>
 
-  <class name="watershed_segmentation/watershed_segmentation" type="watershed_segmentation::WatershedSegmentationNodelet" base_class_type="nodelet::Nodelet">
+  <class name="opencv_apps/watershed_segmentation" type="watershed_segmentation::WatershedSegmentationNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to demonstrate the famous watershed segmentation algorithm in OpenCV: watershed()</description>
   </class>
 


### PR DESCRIPTION
format of nodelet_plugins.xml is

```
  <class name="example_pkg/MyNodeletClass" type="example_pkg::MyNodeletClass" base_class_type="nodelet::Nodelet">
```

http://wiki.ros.org/nodelet/Tutorials/Porting%20nodes%20to%20nodelets

If someonf is using nodelet already, this breaks API

@iory
