### PR TITLE
force convert to bgr for display

### DIFF
--- a/src/nodelet/adding_images_nodelet.cpp
+++ b/src/nodelet/adding_images_nodelet.cpp
@@ -166,19 +166,9 @@ namespace adding_images {
       // Work on the image.
       try {
         cv::Mat image1 =
-          cv_bridge::toCvShare(image_msg1, image_msg1->encoding)->image;
+          cv_bridge::toCvShare(image_msg1, sensor_msgs::image_encodings::BGR8)->image;
         cv::Mat image2 =
-          cv_bridge::toCvShare(image_msg2, image_msg2->encoding)->image;
-
-        // convert image to bgr8
-        if (image_msg1->encoding == sensor_msgs::image_encodings::RGB8 ||
-            image_msg1->encoding == sensor_msgs::image_encodings::RGB16) {
-          cv::cvtColor(image1, image1, CV_RGB2BGR);
-        }
-        if (image_msg2->encoding == sensor_msgs::image_encodings::RGB8 ||
-            image_msg2->encoding == sensor_msgs::image_encodings::RGB16) {
-          cv::cvtColor(image2, image2, CV_RGB2BGR);
-        }
+          cv_bridge::toCvShare(image_msg2, sensor_msgs::image_encodings::BGR8)->image;
 
         cv::Mat result_image;
         cv::addWeighted(image1, alpha_, image2, beta_, gamma_, result_image);

--- a/src/nodelet/camshift_nodelet.cpp
+++ b/src/nodelet/camshift_nodelet.cpp
@@ -44,6 +44,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <iostream>
 #include <ctype.h>

--- a/src/nodelet/camshift_nodelet.cpp
+++ b/src/nodelet/camshift_nodelet.cpp
@@ -140,7 +140,7 @@ class CamShiftNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
       cv::Mat backproj;
       
       // Messages

--- a/src/nodelet/contour_moments_nodelet.cpp
+++ b/src/nodelet/contour_moments_nodelet.cpp
@@ -111,7 +111,7 @@ class ContourMomentsNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::MomentArrayStamped moments_msg;

--- a/src/nodelet/convex_hull_nodelet.cpp
+++ b/src/nodelet/convex_hull_nodelet.cpp
@@ -44,6 +44,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/convex_hull_nodelet.cpp
+++ b/src/nodelet/convex_hull_nodelet.cpp
@@ -111,7 +111,7 @@ class ConvexHullNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::ContourArrayStamped contours_msg;

--- a/src/nodelet/edge_detection_nodelet.cpp
+++ b/src/nodelet/edge_detection_nodelet.cpp
@@ -134,7 +134,7 @@ class EdgeDetectionNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Do the work
       cv::Mat src_gray;

--- a/src/nodelet/face_detection_nodelet.cpp
+++ b/src/nodelet/face_detection_nodelet.cpp
@@ -103,7 +103,7 @@ class FaceDetectionNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::FaceArrayStamped faces_msg;

--- a/src/nodelet/face_detection_nodelet.cpp
+++ b/src/nodelet/face_detection_nodelet.cpp
@@ -43,6 +43,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/objdetect/objdetect.hpp>
 #include <opencv2/highgui/highgui.hpp>

--- a/src/nodelet/fback_flow_nodelet.cpp
+++ b/src/nodelet/fback_flow_nodelet.cpp
@@ -42,6 +42,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/fback_flow_nodelet.cpp
+++ b/src/nodelet/fback_flow_nodelet.cpp
@@ -107,7 +107,7 @@ class FBackFlowNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::FlowArrayStamped flows_msg;

--- a/src/nodelet/find_contours_nodelet.cpp
+++ b/src/nodelet/find_contours_nodelet.cpp
@@ -111,7 +111,7 @@ class FindContoursNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::ContourArrayStamped contours_msg;

--- a/src/nodelet/find_contours_nodelet.cpp
+++ b/src/nodelet/find_contours_nodelet.cpp
@@ -44,6 +44,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/general_contours_nodelet.cpp
+++ b/src/nodelet/general_contours_nodelet.cpp
@@ -111,7 +111,7 @@ class GeneralContoursNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::RotatedRectArrayStamped rects_msg, ellipses_msg;

--- a/src/nodelet/general_contours_nodelet.cpp
+++ b/src/nodelet/general_contours_nodelet.cpp
@@ -44,6 +44,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/goodfeature_track_nodelet.cpp
+++ b/src/nodelet/goodfeature_track_nodelet.cpp
@@ -43,6 +43,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/goodfeature_track_nodelet.cpp
+++ b/src/nodelet/goodfeature_track_nodelet.cpp
@@ -109,7 +109,7 @@ class GoodfeatureTrackNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::Point2DArrayStamped corners_msg;

--- a/src/nodelet/hough_circles_nodelet.cpp
+++ b/src/nodelet/hough_circles_nodelet.cpp
@@ -144,7 +144,7 @@ class HoughCirclesNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::CircleArrayStamped circles_msg;

--- a/src/nodelet/hough_circles_nodelet.cpp
+++ b/src/nodelet/hough_circles_nodelet.cpp
@@ -44,6 +44,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/hough_lines_nodelet.cpp
+++ b/src/nodelet/hough_lines_nodelet.cpp
@@ -121,7 +121,7 @@ class HoughLinesNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat in_image = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat in_image = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
       cv::Mat src_gray;
 
       if (in_image.channels() > 1) {

--- a/src/nodelet/hough_lines_nodelet.cpp
+++ b/src/nodelet/hough_lines_nodelet.cpp
@@ -44,6 +44,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/lk_flow_nodelet.cpp
+++ b/src/nodelet/lk_flow_nodelet.cpp
@@ -126,11 +126,7 @@ class LKFlowNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat image = cv_bridge::toCvShare(msg, msg->encoding)->image;
-      if (msg->encoding == sensor_msgs::image_encodings::RGB8 ||
-          msg->encoding == sensor_msgs::image_encodings::RGB16) {
-        cv::cvtColor(image, image, cv::COLOR_RGB2BGR);
-      }
+      cv::Mat image = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::FlowArrayStamped flows_msg;

--- a/src/nodelet/lk_flow_nodelet.cpp
+++ b/src/nodelet/lk_flow_nodelet.cpp
@@ -42,6 +42,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/people_detect_nodelet.cpp
+++ b/src/nodelet/people_detect_nodelet.cpp
@@ -119,7 +119,7 @@ class PeopleDetectNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::RectArrayStamped found_msg;

--- a/src/nodelet/people_detect_nodelet.cpp
+++ b/src/nodelet/people_detect_nodelet.cpp
@@ -42,6 +42,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/phase_corr_nodelet.cpp
+++ b/src/nodelet/phase_corr_nodelet.cpp
@@ -38,6 +38,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/phase_corr_nodelet.cpp
+++ b/src/nodelet/phase_corr_nodelet.cpp
@@ -102,7 +102,7 @@ class PhaseCorrNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::Point2DStamped shift_msg;

--- a/src/nodelet/segment_objects_nodelet.cpp
+++ b/src/nodelet/segment_objects_nodelet.cpp
@@ -41,6 +41,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/segment_objects_nodelet.cpp
+++ b/src/nodelet/segment_objects_nodelet.cpp
@@ -116,7 +116,7 @@ class SegmentObjectsNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::ContourArrayStamped contours_msg;
@@ -203,7 +203,7 @@ class SegmentObjectsNodelet : public opencv_apps::Nodelet
       }
 
       // Publish the image.
-      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, "bgr8", out_frame).toImageMsg();
+      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, sensor_msgs::image_encodings::BGR8, out_frame).toImageMsg();
       img_pub_.publish(out_img);
       msg_pub_.publish(contours_msg);
       area_pub_.publish(area_msg);

--- a/src/nodelet/simple_compressed_example_nodelet.cpp
+++ b/src/nodelet/simple_compressed_example_nodelet.cpp
@@ -43,6 +43,7 @@
 #include <nodelet/nodelet.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/simple_flow_nodelet.cpp
+++ b/src/nodelet/simple_flow_nodelet.cpp
@@ -112,7 +112,7 @@ class SimpleFlowNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame_src = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame_src = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       /// Convert it to gray
       cv::Mat frame;

--- a/src/nodelet/simple_flow_nodelet.cpp
+++ b/src/nodelet/simple_flow_nodelet.cpp
@@ -41,6 +41,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>

--- a/src/nodelet/threshold_nodelet.cpp
+++ b/src/nodelet/threshold_nodelet.cpp
@@ -41,6 +41,8 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+
 #include <opencv2/highgui/highgui.hpp>
 #include "opencv2/imgproc/imgproc.hpp"
 

--- a/src/nodelet/threshold_nodelet.cpp
+++ b/src/nodelet/threshold_nodelet.cpp
@@ -114,7 +114,7 @@ namespace threshold {
                   const std::string input_frame_from_msg) {
       try {
         cv::Mat src_image =
-          cv_bridge::toCvShare(image_msg, image_msg->encoding)->image;
+          cv_bridge::toCvShare(image_msg, sensor_msgs::image_encodings::BGR8)->image;
         cv::Mat gray_image;
         cv::cvtColor(src_image, gray_image, cv::COLOR_BGR2GRAY);
         cv::Mat result_image;

--- a/src/nodelet/watershed_segmentation_nodelet.cpp
+++ b/src/nodelet/watershed_segmentation_nodelet.cpp
@@ -124,7 +124,7 @@ class WatershedSegmentationNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
 
       // Messages
       opencv_apps::ContourArrayStamped contours_msg;

--- a/src/nodelet/watershed_segmentation_nodelet.cpp
+++ b/src/nodelet/watershed_segmentation_nodelet.cpp
@@ -41,6 +41,7 @@
 #include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>


### PR DESCRIPTION
@wkentaro please review, and do I have to change other codes as well?
I do not use cvtColorForDisplay because someone still want to compile this on hydro.

```
$ grep toCvS ../src/nodelet/*
../src/nodelet/adding_images_nodelet.cpp:          cv_bridge::toCvShare(image_msg1, image_msg1->encoding)->image;
../src/nodelet/adding_images_nodelet.cpp:          cv_bridge::toCvShare(image_msg2, image_msg2->encoding)->image;
../src/nodelet/camshift_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, "bgr8")->image;
../src/nodelet/contour_moments_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/convex_hull_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/edge_detection_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/face_detection_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/fback_flow_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/find_contours_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/general_contours_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/goodfeature_track_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/hough_circles_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/hough_lines_nodelet.cpp:      cv::Mat in_image = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/lk_flow_nodelet.cpp:      cv::Mat image = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/people_detect_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/phase_corr_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/segment_objects_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/simple_flow_nodelet.cpp:      cv::Mat frame_src = cv_bridge::toCvShare(msg, msg->encoding)->image;
../src/nodelet/threshold_nodelet.cpp:          cv_bridge::toCvShare(image_msg, image_msg->encoding)->image;
../src/nodelet/watershed_segmentation_nodelet.cpp:      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
```
