### PR TITLE
Set useless use_camera_info flag to false in default

### DIFF
--- a/cfg/AddingImages.cfg
+++ b/cfg/AddingImages.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("alpha", double_t, 0, "weight of the first array elements.", 0.5, 0.0, 1.0)
 gen.add("auto_beta", bool_t, 0, "True: Automatically set beta weight as 1 - alpha, False: Use user defined beta weight", True)

--- a/cfg/CamShift.cfg
+++ b/cfg/CamShift.cfg
@@ -37,7 +37,7 @@ PACKAGE='camshift'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("vmin", int_t, 0, "Vmin",  10, 1, 256)
 gen.add("vmax", int_t, 0, "Vmax", 256, 1, 256)

--- a/cfg/ContourMoments.cfg
+++ b/cfg/ContourMoments.cfg
@@ -37,7 +37,7 @@ PACKAGE='contour_moments'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("canny_low_threshold", int_t, 0, "Canny Edge low Threshold", 100, 1, 255)
 

--- a/cfg/ConvexHull.cfg
+++ b/cfg/ConvexHull.cfg
@@ -37,7 +37,7 @@ PACKAGE='convex_hull'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("threshold", int_t, 0, "Detect edges using Threshold", 100, 1, 255)
 

--- a/cfg/CornerHarris.cfg
+++ b/cfg/CornerHarris.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 gen.add("threshold", int_t, 0, "Threshold of corner.", 200, 0, 255)
 
 exit(gen.generate(PACKAGE, "corner_harris", "CornerHarris"))

--- a/cfg/DiscreteFourierTransform.cfg
+++ b/cfg/DiscreteFourierTransform.cfg
@@ -6,6 +6,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "discrete_fourier_transform", "DiscreteFourierTransform"))

--- a/cfg/EdgeDetection.cfg
+++ b/cfg/EdgeDetection.cfg
@@ -37,7 +37,7 @@ PACKAGE='edge_detection'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 edge_type = gen.enum([ gen.const("Sobel",   int_t,  0, "Sobel Derivatives"),
                        gen.const("Laplace", int_t,  1, "Laplace Operator"),

--- a/cfg/FBackFlow.cfg
+++ b/cfg/FBackFlow.cfg
@@ -37,6 +37,6 @@ PACKAGE='fback_flow'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "fback_flow", "FBackFlow"))

--- a/cfg/FaceDetection.cfg
+++ b/cfg/FaceDetection.cfg
@@ -37,6 +37,6 @@ PACKAGE='face_detection'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "face_detection", "FaceDetection"))

--- a/cfg/FindContours.cfg
+++ b/cfg/FindContours.cfg
@@ -37,7 +37,7 @@ PACKAGE='find_contours'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("canny_low_threshold", int_t, 0, "Canny Edge low Threshold", 10, 1, 255)
 

--- a/cfg/GeneralContours.cfg
+++ b/cfg/GeneralContours.cfg
@@ -37,7 +37,7 @@ PACKAGE='general_contours'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("threshold", int_t, 0, "Detect edges using Threshold", 100, 1, 255)
 

--- a/cfg/GoodfeatureTrack.cfg
+++ b/cfg/GoodfeatureTrack.cfg
@@ -37,7 +37,7 @@ PACKAGE='goodfeature_track'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("max_corners", int_t, 0, "Max Number of Corners", 23, 1, 100)
 

--- a/cfg/HLSColorFilter.cfg
+++ b/cfg/HLSColorFilter.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add ("h_limit_max", int_t, 0, "The maximum allowed field value Hue", 360, 0, 360)
 gen.add ("h_limit_min", int_t, 0, "The minimum allowed field value Hue", 0, 0, 360)

--- a/cfg/HSIColorFilter.cfg
+++ b/cfg/HSIColorFilter.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add ("h_limit_max", int_t, 0, "The maximum allowed field value Hue", 255, 0, 255)
 gen.add ("h_limit_min", int_t, 0, "The minimum allowed field value Hue", 0, 0, 255)

--- a/cfg/HSVColorFilter.cfg
+++ b/cfg/HSVColorFilter.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add ("h_limit_max", int_t, 0, "The maximum allowed field value Hue", 360, 0, 360)
 gen.add ("h_limit_min", int_t, 0, "The minimum allowed field value Hue", 0, 0, 360)

--- a/cfg/HoughCircles.cfg
+++ b/cfg/HoughCircles.cfg
@@ -37,7 +37,7 @@ PACKAGE='hough_circles'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("canny_threshold", double_t, 0, "Canny threshold", 200, 1, 255)
 gen.add("accumulator_threshold", double_t, 0, "Accumulator threshold", 50, 1, 200)

--- a/cfg/HoughLines.cfg
+++ b/cfg/HoughLines.cfg
@@ -37,7 +37,7 @@ PACKAGE='hough_lines'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 hough_type = gen.enum([ gen.const("Standard_Hough_Transform",   int_t,  0, "Standard Hough Line"),
                         gen.const("Probabilistic_Hough_Transform",   int_t,  1, "Probabilistic Hough Line")], "An enum for Hough Transform Mehtods")

--- a/cfg/LKFlow.cfg
+++ b/cfg/LKFlow.cfg
@@ -37,6 +37,6 @@ PACKAGE='lk_flow'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "lk_flow", "LKFlow"))

--- a/cfg/PeopleDetect.cfg
+++ b/cfg/PeopleDetect.cfg
@@ -37,7 +37,7 @@ PACKAGE='people_detect'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("hit_threshold", double_t, 150, "Threshold for the distance between features and SVM classifying plane.", 0, 0, 10)
 gen.add("win_stride", int_t, 8, "Window stride. It must be a multiple of block stride.", 8, 1, 100)

--- a/cfg/PhaseCorr.cfg
+++ b/cfg/PhaseCorr.cfg
@@ -37,6 +37,6 @@ PACKAGE='phase_corr'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "phase_corr", "PhaseCorr"))

--- a/cfg/RGBColorFilter.cfg
+++ b/cfg/RGBColorFilter.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("r_limit_max", int_t, 0, "The maximum allowed field value Red", 255, 0, 255)
 gen.add("r_limit_min", int_t, 0, "The minimum allowed field value Red", 0, 0, 255)

--- a/cfg/SegmentObjects.cfg
+++ b/cfg/SegmentObjects.cfg
@@ -37,6 +37,6 @@ PACKAGE='segment_objects'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "segment_objects", "SegmentObjects"))

--- a/cfg/SimpleFlow.cfg
+++ b/cfg/SimpleFlow.cfg
@@ -37,7 +37,7 @@ PACKAGE='simple_flow'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 gen.add("scale", int_t, 0, "Scale", 4, 1, 24)
 

--- a/cfg/Smoothing.cfg
+++ b/cfg/Smoothing.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *;
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 filter_type = gen.enum([ gen.const("Homogeneous_Blur",   int_t,  0, "Homogeneous blur"),
                          gen.const("Gaussian_Blur",   int_t,  1, "Gaussian blur"),
                          gen.const("Median_Blur",   int_t,  2, "Median blur"),

--- a/cfg/Threshold.cfg
+++ b/cfg/Threshold.cfg
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 threshold_type = gen.enum([gen.const("Binary",   int_t,  0, "Binary"),
                            gen.const("Binary_Inverted",   int_t,  1, "Binary Inverted"),
                            gen.const("Threshold_Truncated",   int_t,  2, "Threshold Truncated"),

--- a/cfg/WatershedSegmentation.cfg
+++ b/cfg/WatershedSegmentation.cfg
@@ -37,6 +37,6 @@ PACKAGE='watershed_segmentation'
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", True)
+gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
 
 exit(gen.generate(PACKAGE, "watershed_segmentation", "WatershedSegmentation"))


### PR DESCRIPTION
This changes current behavior a little, but won't break current programs because all programs work without camera_info in actual.
IMO, camera_info should not be subscribed if it is not used.

cc @iory 