### PR TITLE
Add color space output for rgb/hsl/hsv color filters

### DIFF
--- a/src/nodelet/color_filter_nodelet.cpp
+++ b/src/nodelet/color_filter_nodelet.cpp
@@ -270,35 +270,38 @@ protected:
   {
     cv::inRange(input_image, lower_color_range_, upper_color_range_, output_image);
 
-    /// publish color spaces
-    if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
+    if (color_space_pub_.getNumSubscribers() > 0)
     {
-      color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
-      color_space_msg_.width = input_image.cols;
-      color_space_msg_.height = input_image.rows;
-      color_space_msg_.point_step = 16;
-      color_space_msg_.row_step = color_space_msg_.width;
-    }
-    for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
-    {
-      unsigned char r = input_image.at<cv::Vec3b>(i)[0];
-      unsigned char g = input_image.at<cv::Vec3b>(i)[1];
-      unsigned char b = input_image.at<cv::Vec3b>(i)[2];
-      float x = r / 255.0;
-      float y = g / 255.0;
-      float z = b / 255.0;
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
-      if (output_image.at<unsigned char>(i) == 0)
+      /// publish color spaces
+      if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
       {
-        unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
-        r = g = b = gray;
+        color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
+        color_space_msg_.width = input_image.cols;
+        color_space_msg_.height = input_image.rows;
+        color_space_msg_.point_step = 16;
+        color_space_msg_.row_step = color_space_msg_.width;
       }
-      unsigned char rgb[4] = { r, g, b, 0 };
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
+      for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
+      {
+        unsigned char r = input_image.at<cv::Vec3b>(i)[0];
+        unsigned char g = input_image.at<cv::Vec3b>(i)[1];
+        unsigned char b = input_image.at<cv::Vec3b>(i)[2];
+        float x = r / 255.0;
+        float y = g / 255.0;
+        float z = b / 255.0;
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
+        if (output_image.at<unsigned char>(i) == 0)
+        {
+          unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
+          r = g = b = gray;
+        }
+        unsigned char rgb[4] = { r, g, b, 0 };
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
+      }
+      color_space_pub_.publish(color_space_msg_);
     }
-    color_space_pub_.publish(color_space_msg_);
   }
 
 protected:
@@ -371,38 +374,41 @@ protected:
       output_image = output_image_0 | output_image_360;
     }
 
-    /// publish color spaces
-    if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
+    if (color_space_pub_.getNumSubscribers() > 0)
     {
-      color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
-      color_space_msg_.width = input_image.cols;
-      color_space_msg_.height = input_image.rows;
-      color_space_msg_.point_step = 16;
-      color_space_msg_.row_step = color_space_msg_.width;
-    }
-    for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
-    {
-      unsigned char r = input_image.at<cv::Vec3b>(i)[0];
-      unsigned char g = input_image.at<cv::Vec3b>(i)[1];
-      unsigned char b = input_image.at<cv::Vec3b>(i)[2];
-      float h = hls_image.at<cv::Vec3b>(i)[0] * 2;
-      float l = hls_image.at<cv::Vec3b>(i)[1] / 255.0;
-      float s = hls_image.at<cv::Vec3b>(i)[2] / 255.0;
-      float x = s * cos(h * M_PI / 180.0);
-      float y = s * sin(h * M_PI / 180.0);
-      float z = l;
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
-      if (output_image.at<unsigned char>(i) == 0)
+      /// publish color spaces
+      if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
       {
-        unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
-        r = g = b = gray;
+        color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
+        color_space_msg_.width = input_image.cols;
+        color_space_msg_.height = input_image.rows;
+        color_space_msg_.point_step = 16;
+        color_space_msg_.row_step = color_space_msg_.width;
       }
-      unsigned char rgb[4] = { r, g, b, 0 };
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
+      for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
+      {
+        unsigned char r = input_image.at<cv::Vec3b>(i)[0];
+        unsigned char g = input_image.at<cv::Vec3b>(i)[1];
+        unsigned char b = input_image.at<cv::Vec3b>(i)[2];
+        float h = hls_image.at<cv::Vec3b>(i)[0] * 2;
+        float l = hls_image.at<cv::Vec3b>(i)[1] / 255.0;
+        float s = hls_image.at<cv::Vec3b>(i)[2] / 255.0;
+        float x = s * cos(h * M_PI / 180.0);
+        float y = s * sin(h * M_PI / 180.0);
+        float z = l;
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
+        if (output_image.at<unsigned char>(i) == 0)
+        {
+          unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
+          r = g = b = gray;
+        }
+        unsigned char rgb[4] = { r, g, b, 0 };
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
+      }
+      color_space_pub_.publish(color_space_msg_);
     }
-    color_space_pub_.publish(color_space_msg_);
   }
 
 public:
@@ -471,38 +477,41 @@ protected:
       cv::inRange(hsv_image, lower_color_range_360, upper_color_range_360, output_image_360);
       output_image = output_image_0 | output_image_360;
     }
-    /// publish color spaces
-    if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
+    if (color_space_pub_.getNumSubscribers() > 0)
     {
-      color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
-      color_space_msg_.width = input_image.cols;
-      color_space_msg_.height = input_image.rows;
-      color_space_msg_.point_step = 16;
-      color_space_msg_.row_step = color_space_msg_.width;
-    }
-    for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
-    {
-      unsigned char r = input_image.at<cv::Vec3b>(i)[0];
-      unsigned char g = input_image.at<cv::Vec3b>(i)[1];
-      unsigned char b = input_image.at<cv::Vec3b>(i)[2];
-      float h = hsv_image.at<cv::Vec3b>(i)[0] * 2;
-      float s = hsv_image.at<cv::Vec3b>(i)[1] / 255.0;
-      float v = hsv_image.at<cv::Vec3b>(i)[2] / 255.0;
-      float x = s * cos(h * M_PI / 180.0);
-      float y = s * sin(h * M_PI / 180.0);
-      float z = v;
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
-      if (output_image.at<unsigned char>(i) == 0)
+      /// publish color spaces
+      if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
       {
-        unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
-        r = g = b = gray;
+        color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
+        color_space_msg_.width = input_image.cols;
+        color_space_msg_.height = input_image.rows;
+        color_space_msg_.point_step = 16;
+        color_space_msg_.row_step = color_space_msg_.width;
       }
-      unsigned char rgb[4] = { r, g, b, 0 };
-      memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
+      for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
+      {
+        unsigned char r = input_image.at<cv::Vec3b>(i)[0];
+        unsigned char g = input_image.at<cv::Vec3b>(i)[1];
+        unsigned char b = input_image.at<cv::Vec3b>(i)[2];
+        float h = hsv_image.at<cv::Vec3b>(i)[0] * 2;
+        float s = hsv_image.at<cv::Vec3b>(i)[1] / 255.0;
+        float v = hsv_image.at<cv::Vec3b>(i)[2] / 255.0;
+        float x = s * cos(h * M_PI / 180.0);
+        float y = s * sin(h * M_PI / 180.0);
+        float z = v;
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
+        if (output_image.at<unsigned char>(i) == 0)
+        {
+          unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
+          r = g = b = gray;
+        }
+        unsigned char rgb[4] = { r, g, b, 0 };
+        memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
+      }
+      color_space_pub_.publish(color_space_msg_);
     }
-    color_space_pub_.publish(color_space_msg_);
   }
 
 public:

--- a/src/nodelet/color_filter_nodelet.cpp
+++ b/src/nodelet/color_filter_nodelet.cpp
@@ -62,15 +62,17 @@ class HSVColorFilter;
 
 // http://stackoverflow.com/questions/12703305/how-to-compare-scalars-in-opencv
 // Custom operator to compare cv::Scalar class...
-bool operator <(const cv::Scalar &a, const cv::Scalar &b)
+bool operator<(const cv::Scalar& a, const cv::Scalar& b)
 {
-  bool Result = true;
+  bool result = true;
   // Do whatever you think a Scalar comparison must be.
-  std::cerr << a.depth <<  " " << a.channels << std::endl;
-  for ( size_t i = 0 ; i < 4; i++ ) {
-    if ( a[i] >= b[i] ) Result = false;
+  std::cerr << a.depth << " " << a.channels << std::endl;
+  for (size_t i = 0; i < 4; i++)
+  {
+    if (a[i] >= b[i])
+      result = false;
   }
-  return Result;
+  return result;
 }
 
 template <typename Config>
@@ -270,29 +272,32 @@ protected:
     cv::inRange(input_image, lower_color_range_, upper_color_range_, output_image);
 
     /// publish color spaces
-    if ( color_space_msg_.data.size() != 16*input_image.rows*input_image.cols) {
-      color_space_msg_.data.resize(16*input_image.rows*input_image.cols);
+    if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
+    {
+      color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
       color_space_msg_.width = input_image.cols;
       color_space_msg_.height = input_image.rows;
       color_space_msg_.point_step = 16;
       color_space_msg_.row_step = color_space_msg_.width;
     }
-    for ( size_t i = 0; i < input_image.rows *  input_image.cols; i++ ) {
+    for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
+    {
       unsigned char r = input_image.at<cv::Vec3b>(i)[0];
       unsigned char g = input_image.at<cv::Vec3b>(i)[1];
       unsigned char b = input_image.at<cv::Vec3b>(i)[2];
-      float x = r/255.0;
-      float y = g/255.0;
-      float z = b/255.0;
-      memcpy((void *)(&(color_space_msg_.data[i*16+0])), (const void *)&x, sizeof(float));
-      memcpy((void *)(&(color_space_msg_.data[i*16+4])), (const void *)&y, sizeof(float));
-      memcpy((void *)(&(color_space_msg_.data[i*16+8])), (const void *)&z, sizeof(float));
-      if ( output_image.at<unsigned char>(i) == 0 ) {
-        unsigned char gray = 16 + (r/3 + g/3 + b/3)*(255-16)/255;
+      float x = r / 255.0;
+      float y = g / 255.0;
+      float z = b / 255.0;
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
+      if (output_image.at<unsigned char>(i) == 0)
+      {
+        unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
         r = g = b = gray;
       }
-      unsigned char rgb[4] = {r, g, b, 0};
-      memcpy((void *)(&(color_space_msg_.data[i*16+12])), (const void *)rgb, 4*sizeof(unsigned char));
+      unsigned char rgb[4] = { r, g, b, 0 };
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
     }
     color_space_pub_.publish(color_space_msg_);
   }
@@ -368,32 +373,35 @@ protected:
     }
 
     /// publish color spaces
-    if ( color_space_msg_.data.size() != 16*input_image.rows*input_image.cols) {
-      color_space_msg_.data.resize(16*input_image.rows*input_image.cols);
+    if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
+    {
+      color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
       color_space_msg_.width = input_image.cols;
       color_space_msg_.height = input_image.rows;
       color_space_msg_.point_step = 16;
       color_space_msg_.row_step = color_space_msg_.width;
     }
-    for ( size_t i = 0; i < input_image.rows *  input_image.cols; i++ ) {
+    for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
+    {
       unsigned char r = input_image.at<cv::Vec3b>(i)[0];
       unsigned char g = input_image.at<cv::Vec3b>(i)[1];
       unsigned char b = input_image.at<cv::Vec3b>(i)[2];
-      float h = hls_image.at<cv::Vec3b>(i)[0]*2;
-      float l = hls_image.at<cv::Vec3b>(i)[1]/255.0;
-      float s = hls_image.at<cv::Vec3b>(i)[2]/255.0;
-      float x = s*cos(h*M_PI/180.0);
-      float y = s*sin(h*M_PI/180.0);
+      float h = hls_image.at<cv::Vec3b>(i)[0] * 2;
+      float l = hls_image.at<cv::Vec3b>(i)[1] / 255.0;
+      float s = hls_image.at<cv::Vec3b>(i)[2] / 255.0;
+      float x = s * cos(h * M_PI / 180.0);
+      float y = s * sin(h * M_PI / 180.0);
       float z = l;
-      memcpy((void *)(&(color_space_msg_.data[i*16+0])), (const void *)&x, sizeof(float));
-      memcpy((void *)(&(color_space_msg_.data[i*16+4])), (const void *)&y, sizeof(float));
-      memcpy((void *)(&(color_space_msg_.data[i*16+8])), (const void *)&z, sizeof(float));
-      if ( output_image.at<unsigned char>(i) == 0 ) {
-        unsigned char gray = 16 + (r/3 + g/3 + b/3)*(255-16)/255;
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
+      if (output_image.at<unsigned char>(i) == 0)
+      {
+        unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
         r = g = b = gray;
       }
-      unsigned char rgb[4] = {r, g, b, 0};
-      memcpy((void *)(&(color_space_msg_.data[i*16+12])), (const void *)rgb, 4*sizeof(unsigned char));
+      unsigned char rgb[4] = { r, g, b, 0 };
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
     }
     color_space_pub_.publish(color_space_msg_);
   }
@@ -465,32 +473,35 @@ protected:
       output_image = output_image_0 | output_image_360;
     }
     /// publish color spaces
-    if ( color_space_msg_.data.size() != 16*input_image.rows*input_image.cols) {
-      color_space_msg_.data.resize(16*input_image.rows*input_image.cols);
+    if (color_space_msg_.data.size() != 16 * input_image.rows * input_image.cols)
+    {
+      color_space_msg_.data.resize(16 * input_image.rows * input_image.cols);
       color_space_msg_.width = input_image.cols;
       color_space_msg_.height = input_image.rows;
       color_space_msg_.point_step = 16;
       color_space_msg_.row_step = color_space_msg_.width;
     }
-    for ( size_t i = 0; i < input_image.rows *  input_image.cols; i++ ) {
+    for (size_t i = 0; i < input_image.rows * input_image.cols; i++)
+    {
       unsigned char r = input_image.at<cv::Vec3b>(i)[0];
       unsigned char g = input_image.at<cv::Vec3b>(i)[1];
       unsigned char b = input_image.at<cv::Vec3b>(i)[2];
-      float h = hsv_image.at<cv::Vec3b>(i)[0]*2;
-      float s = hsv_image.at<cv::Vec3b>(i)[1]/255.0;
-      float v = hsv_image.at<cv::Vec3b>(i)[2]/255.0;
-      float x = s*cos(h*M_PI/180.0);
-      float y = s*sin(h*M_PI/180.0);
+      float h = hsv_image.at<cv::Vec3b>(i)[0] * 2;
+      float s = hsv_image.at<cv::Vec3b>(i)[1] / 255.0;
+      float v = hsv_image.at<cv::Vec3b>(i)[2] / 255.0;
+      float x = s * cos(h * M_PI / 180.0);
+      float y = s * sin(h * M_PI / 180.0);
       float z = v;
-      memcpy((void *)(&(color_space_msg_.data[i*16+0])), (const void *)&x, sizeof(float));
-      memcpy((void *)(&(color_space_msg_.data[i*16+4])), (const void *)&y, sizeof(float));
-      memcpy((void *)(&(color_space_msg_.data[i*16+8])), (const void *)&z, sizeof(float));
-      if ( output_image.at<unsigned char>(i) == 0 ) {
-        unsigned char gray = 16 + (r/3 + g/3 + b/3)*(255-16)/255;
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 0])), (const void*)&x, sizeof(float));
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 4])), (const void*)&y, sizeof(float));
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 8])), (const void*)&z, sizeof(float));
+      if (output_image.at<unsigned char>(i) == 0)
+      {
+        unsigned char gray = 16 + (r / 3 + g / 3 + b / 3) * (255 - 16) / 255;
         r = g = b = gray;
       }
-      unsigned char rgb[4] = {r, g, b, 0};
-      memcpy((void *)(&(color_space_msg_.data[i*16+12])), (const void *)rgb, 4*sizeof(unsigned char));
+      unsigned char rgb[4] = { r, g, b, 0 };
+      memcpy((void*)(&(color_space_msg_.data[i * 16 + 12])), (const void*)rgb, 4 * sizeof(unsigned char));
     }
     color_space_pub_.publish(color_space_msg_);
   }

--- a/src/nodelet/color_filter_nodelet.cpp
+++ b/src/nodelet/color_filter_nodelet.cpp
@@ -66,7 +66,6 @@ bool operator<(const cv::Scalar& a, const cv::Scalar& b)
 {
   bool result = true;
   // Do whatever you think a Scalar comparison must be.
-  std::cerr << a.depth << " " << a.channels << std::endl;
   for (size_t i = 0; i < 4; i++)
   {
     if (a[i] >= b[i])

--- a/src/nodelet/color_filter_nodelet.cpp
+++ b/src/nodelet/color_filter_nodelet.cpp
@@ -60,6 +60,19 @@ class RGBColorFilter;
 class HLSColorFilter;
 class HSVColorFilter;
 
+// http://stackoverflow.com/questions/12703305/how-to-compare-scalars-in-opencv
+// Custom operator to compare cv::Scalar class...
+bool operator <(const cv::Scalar &a, const cv::Scalar &b)
+{
+  bool Result = true;
+  // Do whatever you think a Scalar comparison must be.
+  std::cerr << a.depth <<  " " << a.channels << std::endl;
+  for ( size_t i = 0 ; i < 4; i++ ) {
+    if ( a[i] >= b[i] ) Result = false;
+  }
+  return Result;
+}
+
 template <typename Config>
 class ColorFilterNodelet : public opencv_apps::Nodelet
 {
@@ -274,6 +287,10 @@ protected:
       memcpy((void *)(&(color_space_msg_.data[i*16+0])), (const void *)&x, sizeof(float));
       memcpy((void *)(&(color_space_msg_.data[i*16+4])), (const void *)&y, sizeof(float));
       memcpy((void *)(&(color_space_msg_.data[i*16+8])), (const void *)&z, sizeof(float));
+      if ( output_image.at<unsigned char>(i) == 0 ) {
+        unsigned char gray = 16 + (r/3 + g/3 + b/3)*(255-16)/255;
+        r = g = b = gray;
+      }
       unsigned char rgb[4] = {r, g, b, 0};
       memcpy((void *)(&(color_space_msg_.data[i*16+12])), (const void *)rgb, 4*sizeof(unsigned char));
     }
@@ -371,6 +388,10 @@ protected:
       memcpy((void *)(&(color_space_msg_.data[i*16+0])), (const void *)&x, sizeof(float));
       memcpy((void *)(&(color_space_msg_.data[i*16+4])), (const void *)&y, sizeof(float));
       memcpy((void *)(&(color_space_msg_.data[i*16+8])), (const void *)&z, sizeof(float));
+      if ( output_image.at<unsigned char>(i) == 0 ) {
+        unsigned char gray = 16 + (r/3 + g/3 + b/3)*(255-16)/255;
+        r = g = b = gray;
+      }
       unsigned char rgb[4] = {r, g, b, 0};
       memcpy((void *)(&(color_space_msg_.data[i*16+12])), (const void *)rgb, 4*sizeof(unsigned char));
     }
@@ -464,6 +485,10 @@ protected:
       memcpy((void *)(&(color_space_msg_.data[i*16+0])), (const void *)&x, sizeof(float));
       memcpy((void *)(&(color_space_msg_.data[i*16+4])), (const void *)&y, sizeof(float));
       memcpy((void *)(&(color_space_msg_.data[i*16+8])), (const void *)&z, sizeof(float));
+      if ( output_image.at<unsigned char>(i) == 0 ) {
+        unsigned char gray = 16 + (r/3 + g/3 + b/3)*(255-16)/255;
+        r = g = b = gray;
+      }
       unsigned char rgb[4] = {r, g, b, 0};
       memcpy((void *)(&(color_space_msg_.data[i*16+12])), (const void *)rgb, 4*sizeof(unsigned char));
     }


### PR DESCRIPTION
Enable to publish color space during filtering
@tongtybj, @chibi314 could you check this node with your example?

rgb space
![rgb](https://cloud.githubusercontent.com/assets/493276/25281358/13d386ea-26e8-11e7-890b-a787b60dc25b.gif)

hls space
![hls](https://cloud.githubusercontent.com/assets/493276/25281366/1c5424aa-26e8-11e7-8f01-e0cf1660a3ed.gif)

hsv space
![hsv](https://cloud.githubusercontent.com/assets/493276/25281741/3ddaf558-26e9-11e7-8f01-dc5a334aa7a4.gif)

```
roslaunch opencv_apps hsv_color_filter.launch image:=/camera/rgb/image_color
```

Discussions

- we publish color space by PointCloud2, is it ok? if we use PointCloud2, we need to set `frame_id` (currently it is `map`) and define scales (1 for now)
- Should we publish threshold? One idea is to publish threshold planes, other is publish point within threshold with colored  and publish outlier points with gray scale


==

input image
![input_color](https://cloud.githubusercontent.com/assets/493276/25277723/d55fa09a-26da-11e7-8f45-cecfba6e89b3.png)

rgb space
![screenshot from 2017-04-21 18 02 33](https://cloud.githubusercontent.com/assets/493276/25277737/e723632a-26da-11e7-92fa-8dcdeb752c7b.png)

hls space
![screenshot from 2017-04-21 21 26 32](https://cloud.githubusercontent.com/assets/493276/25277752/f6e4be94-26da-11e7-8016-3f80205a65f5.png)

hsv space
![screenshot from 2017-04-21 21 27 53](https://cloud.githubusercontent.com/assets/493276/25277765/01ecc84a-26db-11e7-9da0-2fccf061a4c3.png)


https://gist.github.com/k-okada/5c7531cecc5c04abff0674afe35eba06