### PR TITLE
workaround for freezing imshow on kinetic

### DIFF
--- a/src/node/standalone_nodelet_exec.cpp.in
+++ b/src/node/standalone_nodelet_exec.cpp.in
@@ -43,7 +43,10 @@ int main(int argc, char **argv)
                  "\t$ rosrun image_rotate image_rotate image:=<image topic> [transport]");
     }
 
-    nodelet::Loader manager(false);
+    // need to use 1 worker thread to prevent freezing in imshow, calling imshow from mutiple threads
+    //nodelet::Loader manager(false);
+    ros::NodeHandle("~").setParam("num_worker_threads", 1); // need to call   Loader(bool provide_ros_api = true);
+    nodelet::Loader manager(true);
     nodelet::M_string remappings;
     nodelet::V_string my_argv(argv + 1, argv + argc);
     my_argv.push_back("--shutdown-on-close"); // Internal

--- a/src/node/standalone_nodelet_exec.cpp.in
+++ b/src/node/standalone_nodelet_exec.cpp.in
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
 
     // need to use 1 worker thread to prevent freezing in imshow, calling imshow from mutiple threads
     //nodelet::Loader manager(false);
-    ros::NodeHandle("~").setParam("num_worker_threads", 1); // need to call   Loader(bool provide_ros_api = true);
+    ros::param::set("~num_worker_threads", 1); // need to call   Loader(bool provide_ros_api = true);
     nodelet::Loader manager(true);
     nodelet::M_string remappings;
     nodelet::V_string my_argv(argv + 1, argv + argc);


### PR DESCRIPTION
Closes https://github.com/ros-perception/opencv_apps/issues/65

as I reported on https://github.com/ros-perception/image_pipeline/pull/279, imshow freezes multi thread environment (https://github.com/opencv/opencv/issues/8407), and standalone nodelet runs with multiple callback queue, 

This PR force starts nodes with one callback queue