### PR TITLE
Change image encoding argument

### DIFF
--- a/src/nodelet/people_detect_nodelet.cpp
+++ b/src/nodelet/people_detect_nodelet.cpp
@@ -120,7 +120,7 @@ class PeopleDetectNodelet : public opencv_apps::Nodelet
     try
     {
       // Convert the image into something opencv can handle.
-      cv::Mat frame = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8)->image;
+      cv::Mat frame = cv_bridge::toCvShare(msg, msg->encoding)->image;
 
       // Messages
       opencv_apps::RectArrayStamped found_msg;


### PR DESCRIPTION
I had issue using this nodelet with mono8 images.
Changing from BGR8 -> MONO8 worked.
So I supposed this fix is more global.