### PR TITLE
Fix output image encoding

### DIFF
--- a/src/nodelet/lk_flow_nodelet.cpp
+++ b/src/nodelet/lk_flow_nodelet.cpp
@@ -263,7 +263,7 @@ class LKFlowNodelet : public opencv_apps::Nodelet
       cv::swap(prevGray, gray);
 
       // Publish the image.
-      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, msg->encoding, image).toImageMsg();
+      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, sensor_msgs::image_encodings::BGR8, image).toImageMsg();
       img_pub_.publish(out_img);
       msg_pub_.publish(flows_msg);
     }

--- a/src/nodelet/lk_flow_nodelet.cpp
+++ b/src/nodelet/lk_flow_nodelet.cpp
@@ -263,7 +263,8 @@ class LKFlowNodelet : public opencv_apps::Nodelet
       cv::swap(prevGray, gray);
 
       // Publish the image.
-      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, sensor_msgs::image_encodings::BGR8, image).toImageMsg();
+      sensor_msgs::Image::Ptr out_img =
+          cv_bridge::CvImage(msg->header, sensor_msgs::image_encodings::BGR8, image).toImageMsg();
       img_pub_.publish(out_img);
       msg_pub_.publish(flows_msg);
     }


### PR DESCRIPTION
Image is converted to BGR at the top of doWork. If this conversion does
not result in match the input encoding, the published image will have an
incorrect encoding in the message.

This fixes the incorrect encoding such that published message is always BGR8