### PR TITLE
add test to check when adding two images, whcih has different size.

### DIFF
--- a/src/nodelet/adding_images_nodelet.cpp
+++ b/src/nodelet/adding_images_nodelet.cpp
@@ -200,14 +200,14 @@ private:
         int new_rows = std::max(image1.rows, image2.rows);
         int new_cols = std::max(image1.cols, image2.cols);
         // if ( new_rows != image1.rows || new_cols != image1.cols ) {
-        cv::Mat image1 = cv::Mat(new_rows, new_cols, image1.type());
-        image1.copyTo(image1(cv::Rect(0, 0, image1.cols, image1.rows)));
-        image1 = image1.clone();  // need clone becuase toCvShare??
+        cv::Mat image1_tmp = cv::Mat(new_rows, new_cols, image1.type());
+        image1.copyTo(image1_tmp(cv::Rect(0, 0, image1.cols, image1.rows)));
+        image1 = image1_tmp.clone();  // need clone because of toCvShare??
 
         // if ( new_rows != image2.rows || new_cols != image2.cols ) {
-        cv::Mat image2 = cv::Mat(new_rows, new_cols, image2.type());
-        image2.copyTo(image2(cv::Rect(0, 0, image2.cols, image2.rows)));
-        image2 = image2.clone();
+        cv::Mat image2_tmp = cv::Mat(new_rows, new_cols, image2.type());
+        image2.copyTo(image2_tmp(cv::Rect(0, 0, image2.cols, image2.rows)));
+        image2 = image2_tmp.clone();
       }
       cv::addWeighted(image1, alpha_, image2, beta_, gamma_, result_image);
       //-- Show what you got

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,11 @@ add_custom_target(face_data DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/face_data)
 add_dependencies(tests face_data)
 
 #add_rostest(test-apps.test)
-add_rostest(test-adding_images.test ARGS gui:=false)
+find_package(image_proc)
+message(STATUS "check image_proc version (${image_proc_VERSION}), test-adding_images.test check_resize:=true only available since indigo(1.12.0)")
+if("${image_proc_VERSION}" VERSION_GREATER "1.12.0") # test-adding_image.test uses image_proc/resize, which only available since indigo
+  add_rostest(test-adding_images.test ARGS gui:=false)
+endif()
 add_rostest(test-discrete_fourier_transform.test ARGS gui:=false)
 add_rostest(test-smoothing.test ARGS gui:=false)
 add_rostest(test-pyramids.test ARGS gui:=false)

--- a/test/test-adding_images.test
+++ b/test/test-adding_images.test
@@ -1,5 +1,6 @@
 <launch>
   <arg name="gui" default="true" />
+  <arg name="check_resize" default="true" />
   <param name="use_sim_time" value="true" />
   <node name="play_face_bag" pkg="rosbag" type="play" args="-l $(find opencv_apps)/test/face_detector_withface_test_diamondback.bag --clock -r 0.1" />
 
@@ -26,7 +27,8 @@
     <!-- Check bug introduced in 4c4caef. when image1.rows != image2.rows || image1.cols != image2.cols)
          see https://github.com/ros-perception/opencv_apps/issues/99 -->
     <node pkg="nodelet" type="nodelet" name="resize"
-          args="standalone image_proc/resize" output="screen">
+          args="standalone image_proc/resize" output="screen"
+          if="$(arg check_resize)" >
       <remap from="image" to="image_rect_color" />
       <param name="scale_height" value="0.5" />
       <param name="scale_width" value="0.5" />
@@ -52,7 +54,7 @@
       <param name="test_duration" value="1.0" />
     </test>
     <param name="adding_images_test_resize/topic" value="adding_images_resize/image" />
-    <test test-name="adding_images_test_resize" pkg="rostest" type="hztest" name="adding_images_test_resize" time-limit="120" >
+    <test test-name="adding_images_test_resize" pkg="rostest" type="hztest" name="adding_images_test_resize" time-limit="120" if="$(arg check_resize)" >
       <param name="hz" value="30" />
       <param name="hzerror" value="10.0" />
       <param name="test_duration" value="1.0" />

--- a/test/test-adding_images.test
+++ b/test/test-adding_images.test
@@ -23,12 +23,36 @@
       <arg name="approximate_sync" value="false" />
     </include>
 
+    <!-- Check bug introduced in 4c4caef. when image1.rows != image2.rows || image1.cols != image2.cols)
+         see https://github.com/ros-perception/opencv_apps/issues/99 -->
+    <node pkg="nodelet" type="nodelet" name="resize"
+          args="standalone image_proc/resize" output="screen">
+      <remap from="image" to="image_rect_color" />
+      <param name="scale_height" value="0.5" />
+      <param name="scale_width" value="0.5" />
+    </node>
+    <include file="$(find opencv_apps)/launch/adding_images.launch" >
+      <arg name="debug_view" value="$(arg gui)" />
+      <arg name="image1" value="image_rect_color" />
+      <arg name="image2" value="resize/image" />
+      <arg name="alpha" value="0.5" />
+      <arg name="gamma" value="0" />
+      <arg name="approximate_sync" value="false" />
+      <arg name="node_name" default="adding_images_resize" />
+    </include>
+
     <!-- Test Codes -->
     <node name="adding_images_saver_result" pkg="image_view" type="image_saver" args="image:=adding_images/image" >
       <param name="filename_format" value="$(find opencv_apps)/test/adding_images_result.png"/>
     </node>
     <param name="adding_images_test/topic" value="adding_images/image" />
     <test test-name="adding_images_test" pkg="rostest" type="hztest" name="adding_images_test" time-limit="120" >
+      <param name="hz" value="30" />
+      <param name="hzerror" value="10.0" />
+      <param name="test_duration" value="1.0" />
+    </test>
+    <param name="adding_images_test_resize/topic" value="adding_images_resize/image" />
+    <test test-name="adding_images_test_resize" pkg="rostest" type="hztest" name="adding_images_test_resize" time-limit="120" >
       <param name="hz" value="30" />
       <param name="hzerror" value="10.0" />
       <param name="test_duration" value="1.0" />


### PR DESCRIPTION
This test should fix the bug introduced in https://github.com/ros-perception/opencv_apps/commit/4c4caef9a812534cfd2426b6fed30b0a33f4d3d3 

fixed by https://github.com/ros-perception/opencv_apps/pull/101/commits/61adbb9a4797703d67fc64b235832686cbaf572b (#101)