### PR TITLE
contour_moments_nodelet: don't publish empty image

### DIFF
--- a/src/nodelet/contour_moments_nodelet.cpp
+++ b/src/nodelet/contour_moments_nodelet.cpp
@@ -159,7 +159,9 @@ class ContourMomentsNodelet : public opencv_apps::Nodelet
 
       /// Draw contours
       cv::Mat drawing;
-      if (debug_view_)
+      /// Draw moment on drawing only when img_pub_ have subscribers
+      bool publish_drawing = (img_pub_.getNumSubscribers() > 0);
+      if (publish_drawing)
       {
         drawing = cv::Mat::zeros(canny_output.size(), CV_8UC3);
       }
@@ -186,7 +188,7 @@ class ContourMomentsNodelet : public opencv_apps::Nodelet
           mc[i] = cv::Point2f(static_cast<float>(mu[i].m10 / mu[i].m00), static_cast<float>(mu[i].m01 / mu[i].m00));
         }
 
-        if (debug_view_)
+        if (publish_drawing)
         {
           cv::Scalar color = cv::Scalar(rng.uniform(0, 255), rng.uniform(0, 255), rng.uniform(0, 255));
           cv::drawContours(drawing, contours, (int)i, color, 2, 8, hierarchy, 0, cv::Point());
@@ -237,8 +239,11 @@ class ContourMomentsNodelet : public opencv_apps::Nodelet
       }
 
       // Publish the image.
-      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, "bgr8", drawing).toImageMsg();
-      img_pub_.publish(out_img);
+      if (publish_drawing)
+      {
+        sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, "bgr8", drawing).toImageMsg();
+        img_pub_.publish(out_img);
+      }
       msg_pub_.publish(moments_msg);
     }
     catch (cv::Exception& e)


### PR DESCRIPTION
The contour_moments_nodelet published an empty image if
debug_image=false, which resulted in the following warnings during the
tests:

```
$ rostest opencv_apps test-contour_moments.test gui:=false
[ WARN] [1574169943.572135233]: Couldn't save image, no data! (/wide_stereo/left/contour_moments_saver)
```

==

Kei: update: even if debug_image=true, we generete drawing image and publishes only when it is subscribed

based on https://github.com/ros-perception/opencv_apps/pull/101/commits/c8129d07e1087e9fb4b0fe49759cd319cbe6a450 (#101)