### PR TITLE
tests: properly remap camera_info

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,14 +3,30 @@ catkin_download_test_data(face_detector_withface_test_diamondback.bag http://dow
   DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}
   MD5 59126117e049e69d577b7ee27251a6f8
   )
-catkin_download_test_data(vslam_tutorial.bag http://download.ros.org/data/vslam_system/vslam_tutorial.bag
+
+# sensor_msgs/CameraInfo
+catkin_download_test_data(vslam_tutorial_old.bag http://download.ros.org/data/vslam_system/vslam_tutorial.bag
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  FILENAME vslam_tutorial_old.bag
   MD5 f5aece448b7af00a38a993eb71400806
   )
-add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial.bag
-  DEPENDS vslam_tutorial.bag
-  COMMAND rosbag reindex vslam_tutorial.bag --output-dir ${CMAKE_CURRENT_SOURCE_DIR}
-)
+if(sensor_msgs_VERSION VERSION_LESS "1.12.0") # reindex bag file
+  catkin_download_test_data(vslam_tutorial.bag http://download.ros.org/data/vslam_system/vslam_tutorial.bag
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    MD5 f5aece448b7af00a38a993eb71400806
+    )
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial.bag
+    DEPENDS vslam_tutorial_old.bag
+    COMMAND rosbag reindex vslam_tutorial_old.bag --output-dir ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND mv ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial_old.bag ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial.bag
+    )
+else()  # CameraInfo changes since 1.4.0 so we need fix bag file
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial.bag
+    DEPENDS vslam_tutorial_old.bag
+    COMMAND rosbag fix --force vslam_tutorial_old.bag  ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial.bag
+    )
+endif()
+
 add_custom_target(vslam_tutorial_bag DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/vslam_tutorial.bag)
 add_dependencies(tests vslam_tutorial_bag)
 

--- a/test/test-adding_images.test
+++ b/test/test-adding_images.test
@@ -44,8 +44,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="adding_images_saver_result" pkg="image_view" type="image_saver" args="image:=adding_images/image" >
+    <node name="adding_images_saver_result" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/adding_images_result.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="adding_images/image" />
+      <remap from="adding_images/camera_info" to="camera_info" />
     </node>
     <param name="adding_images_test/topic" value="adding_images/image" />
     <test test-name="adding_images_test" pkg="rostest" type="hztest" name="adding_images_test" time-limit="120" >

--- a/test/test-blob-extraction.test
+++ b/test/test-blob-extraction.test
@@ -56,17 +56,29 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="color_filter_saver" pkg="image_view" type="image_saver" args="image:=lab_color_filter/image" >
+    <node name="color_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/blob_extraction_color_filter.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="lab_color_filter/image" />
+      <remap from="lab_color_filter/camera_info" to="camera_info" />
     </node>
-    <node name="blob_extraction_opening_saver" pkg="image_view" type="image_saver" args="image:=opening/image" >
+    <node name="blob_extraction_opening_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/blob_extraction_opening.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="opening/image" />
+      <remap from="opening/camera_info" to="camera_info" />
     </node>
-    <node name="blob_extraction_closing_saver" pkg="image_view" type="image_saver" args="image:=closing/image" >
+    <node name="blob_extraction_closing_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/blob_extraction_closing.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="closing/image" />
+      <remap from="closing/camera_info" to="camera_info" />
     </node>
-    <node name="blob_extraction_ellipses_saver" pkg="image_view" type="image_saver" args="image:=blob_extraction/image" >
+    <node name="blob_extraction_ellipses_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/blob_extraction_ellipses.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="blob_extraction/image" />
+      <remap from="blob_extraction/camera_info" to="camera_info" />
     </node>
     <param name="blob_extraction_test/topic" value="blob_extraction/ellipses" />
     <test test-name="blob_extraction_test" pkg="rostest" type="hztest" name="blob_extraction_test" >

--- a/test/test-blob-extraction.test
+++ b/test/test-blob-extraction.test
@@ -1,7 +1,7 @@
 <launch>
   <arg name="gui" default="true" />
   <param name="use_sim_time" value="true" />
-  <node name="play_face_bag" pkg="rosbag" type="play" args="-l $(find opencv_apps)/test/face_detector_withface_test_diamondback.bag --clock -r 1.0" />
+  <node name="play_face_bag" pkg="rosbag" type="play" args="-l $(find opencv_apps)/test/face_detector_withface_test_diamondback.bag --clock -r 0.025" />
 
   <group ns="wide_stereo/left" >
     <node name="image_proc" pkg="image_proc" type="image_proc" />

--- a/test/test-camshift.test
+++ b/test/test-camshift.test
@@ -18,11 +18,17 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="camshift_saver_result" pkg="image_view" type="image_saver" args="image:=camshift/image" >
+    <node name="camshift_saver_result" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/camshift_result.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="camshift/image" />
+      <remap from="camshift/camera_info" to="camera_info" />
     </node>
-    <node name="camshift_saver_back_project" pkg="image_view" type="image_saver" args="image:=camshift/back_project" >
+    <node name="camshift_saver_back_project" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/camshift_back_project.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="camshift/back_project" />
+      <remap from="camshift/camera_info" to="camera_info" />
     </node>
     <param name="camshift_test/topic" value="camshift/track_box" />    <!-- opencv_apps/Point2DArrayStamped -->
     <test test-name="camshift_test" pkg="rostest" type="hztest" name="camshift_test" >

--- a/test/test-contour_moments.test
+++ b/test/test-contour_moments.test
@@ -16,6 +16,7 @@
     <!-- Test Codes -->
     <node name="contour_moments_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/contour_moments.png"/>
+      <param name="queue_size" value="5" />
       <remap from="image" to="contour_moments/image" />
       <remap from="contour_moments/camera_info" to="camera_info" />
     </node>

--- a/test/test-contour_moments.test
+++ b/test/test-contour_moments.test
@@ -14,8 +14,10 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="contour_moments_saver" pkg="image_view" type="image_saver" args="image:=contour_moments/image" >
+    <node name="contour_moments_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/contour_moments.png"/>
+      <remap from="image" to="contour_moments/image" />
+      <remap from="contour_moments/camera_info" to="camera_info" />
     </node>
     <param name="contour_moments_test/topic" value="contour_moments/moments" />    <!-- opencv_apps/MomentArrayStamped -->
     <test test-name="contour_moments_test" pkg="rostest" type="hztest" name="contour_moments_test" >

--- a/test/test-convex_hull.test
+++ b/test/test-convex_hull.test
@@ -15,8 +15,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="convex_hull_saver" pkg="image_view" type="image_saver" args="image:=convex_hull/image" >
+    <node name="convex_hull_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/convex_hull.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="convex_hull/image" />
+      <remap from="convex_hull/camera_info" to="camera_info" />
     </node>
     <param name="convex_hull_test/topic" value="convex_hull/hulls" />    <!-- opencv_apps/ContorArrayStamped -->
     <test test-name="convex_hull_test" pkg="rostest" type="hztest" name="convex_hull_test" >

--- a/test/test-corner_harris.test
+++ b/test/test-corner_harris.test
@@ -15,8 +15,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="corner_harris_saver" pkg="image_view" type="image_saver" args="image:=corner_harris/image" >
+    <node name="corner_harris_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/corner_harris.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="corner_harris/image" />
+      <remap from="corner_harris/camera_info" to="camera_info" />
     </node>
     <param name="corner_harris_test/topic" value="corner_harris/image" />
     <test test-name="corner_harris_test" pkg="rostest" type="hztest" name="corner_harris_test" >

--- a/test/test-discrete_fourier_transform.test
+++ b/test/test-discrete_fourier_transform.test
@@ -14,8 +14,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="discrete_fourier_transform_saver_result" pkg="image_view" type="image_saver" args="image:=discrete_fourier_transform/image" >
+    <node name="discrete_fourier_transform_saver_result" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/discrete_fourier_transform_result.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="discrete_fourier_transform/image" />
+      <remap from="discrete_fourier_transform/camera_info" to="camera_info" />
     </node>
     <param name="discrete_fourier_transform_test/topic" value="discrete_fourier_transform/image" />
     <test test-name="discrete_fourier_transform_test" pkg="rostest" type="hztest" name="discrete_fourier_transform_test" time-limit="120" >

--- a/test/test-edge_detection.test
+++ b/test/test-edge_detection.test
@@ -17,8 +17,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="edge_sobel_detection_saver" pkg="image_view" type="image_saver" args="image:=edge_sobel_detection/image" >
+    <node name="edge_sobel_detection_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/edge_sobel_detection.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="edge_sobel_detection/image" />
+      <remap from="edge_sobel_detection/camera_info" to="camera_info" />
     </node>
     <param name="edge_sobel_detection_test/topic" value="edge_sobel_detection/image" />    <!-- opencv_apps/FaceArrayStamped -->
     <test test-name="edge_sobel_detection_test" pkg="rostest" type="hztest" name="edge_sobel_detection_test" time-limit="120" >
@@ -35,8 +38,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="edge_laplace_detection_saver" pkg="image_view" type="image_saver" args="image:=edge_laplace_detection/image" >
+    <node name="edge_laplace_detection_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/edge_laplace_detection.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="edge_laplace_detection/image" />
+      <remap from="edge_laplace_detection/camera_info" to="camera_info" />
     </node>
     <param name="edge_laplace_detection_test/topic" value="edge_laplace_detection/image" />    <!-- opencv_apps/FaceArrayStamped -->
     <test test-name="edge_laplace_detection_test" pkg="rostest" type="hztest" name="edge_laplace_detection_test" time-limit="120" >
@@ -53,8 +59,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="edge_canny_detection_saver" pkg="image_view" type="image_saver" args="image:=edge_canny_detection/image" >
+    <node name="edge_canny_detection_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/edge_canny_detection.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="edge_canny_detection/image" />
+      <remap from="edge_canny_detection/camera_info" to="camera_info" />
     </node>
     <param name="edge_canny_detection_test/topic" value="edge_canny_detection/image" />    <!-- opencv_apps/FaceArrayStamped -->
     <test test-name="edge_canny_detection_test" pkg="rostest" type="hztest" name="edge_canny_detection_test" time-limit="120" >

--- a/test/test-face_detection.test
+++ b/test/test-face_detection.test
@@ -29,10 +29,14 @@
     <!-- Test Codes -->
     <node name="face_detection_saver" pkg="image_view" type="image_saver">
       <remap from="image" to="face_detection/image" />
+      <remap from="face_detection/camera_info" to="camera_info" />
+      <param name="queue_size" value="5" />
       <param name="filename_format" value="$(find opencv_apps)/test/face_detection.png"/>
     </node>
     <node name="face_image_saver" pkg="image_view" type="image_saver">
       <remap from="image" to="face_detection/face_image" />
+      <remap from="face_detection/camera_info" to="camera_info" />
+      <param name="queue_size" value="5" />
       <param name="filename_format" value="$(find opencv_apps)/test/face.png" />
     </node>
     <param name="face_detection_test/topic" value="face_detection/faces" />    <!-- opencv_apps/FaceArrayStamped -->

--- a/test/test-fback_flow.test
+++ b/test/test-fback_flow.test
@@ -14,8 +14,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="fback_flow_saver" pkg="image_view" type="image_saver" args="image:=fback_flow/image" >
+    <node name="fback_flow_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/fback_flow.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="fback_flow/image" />
+      <remap from="fback_flow/camera_info" to="camera_info" />
     </node>
     <param name="fback_flow_test/topic" value="fback_flow/flows" />    <!-- opencv_apps/FlowArrayStamped -->
     <test test-name="fback_flow_test" pkg="rostest" type="hztest" name="fback_flow_test" retry="2" >

--- a/test/test-find_contours.test
+++ b/test/test-find_contours.test
@@ -15,8 +15,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="find_contours_saver" pkg="image_view" type="image_saver" args="image:=find_contours/image" >
+    <node name="find_contours_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/find_contours.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="find_contours/image" />
+      <remap from="find_contours/camera_info" to="camera_info" />
     </node>
     <param name="find_contours_test/topic" value="find_contours/contours" />    <!-- opencv_apps/ContorArrayStamped -->
     <test test-name="find_contours_test" pkg="rostest" type="hztest" name="find_contours_test" >

--- a/test/test-general_contours.test
+++ b/test/test-general_contours.test
@@ -15,8 +15,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="general_contours_saver" pkg="image_view" type="image_saver" args="image:=general_contours/image" >
+    <node name="general_contours_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/general_contours.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="general_contours/image" />
+      <remap from="general_contours/camera_info" to="camera_info" />
     </node>
     <param name="general_contours_rectangles_test/topic" value="general_contours/rectangles" />    <!-- opencv_apps/RotatedRectArrayStamped -->
     <test test-name="general_contours_rectangles_test" pkg="rostest" type="hztest" name="general_contours_rectangles_test" >

--- a/test/test-goodfeature_track.test
+++ b/test/test-goodfeature_track.test
@@ -16,8 +16,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="goodfeature_track_saver" pkg="image_view" type="image_saver" args="image:=goodfeature_track/image" >
+    <node name="goodfeature_track_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/goodfeature_track.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="goodfeature_track/image" />
+      <remap from="goodfeature_track/camera_info" to="camera_info" />
     </node>
     <param name="goodfeature_track_test/topic" value="goodfeature_track/corners" />    <!-- opencv_apps/Point2DArrayStamped -->
     <test test-name="goodfeature_track_test" pkg="rostest" type="hztest" name="goodfeature_track_test" >

--- a/test/test-hls_color_filter.test
+++ b/test/test-hls_color_filter.test
@@ -20,8 +20,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="hls_color_filter_saver" pkg="image_view" type="image_saver" args="image:=hls_color_filter/image" >
+    <node name="hls_color_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/hls_color_filter.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="hls_color_filter/image" />
+      <remap from="hls_color_filter/camera_info" to="camera_info" />
     </node>
     <param name="hls_color_filter_test/topic" value="hls_color_filter/image" />
     <test test-name="hls_color_filter_test" pkg="rostest" type="hztest" name="hls_color_filter_test" >

--- a/test/test-hough_circles.test
+++ b/test/test-hough_circles.test
@@ -16,8 +16,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="hough_circles_saver" pkg="image_view" type="image_saver" args="image:=hough_circles/image" >
+    <node name="hough_circles_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/hough_circles.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="hough_circles/image" />
+      <remap from="hough_circles/camera_info" to="camera_info" />
     </node>
     <param name="hough_circles_test/topic" value="hough_circles/circles" />    <!-- opencv_apps/CircleArrayStamped -->
     <test test-name="hough_circles_test" pkg="rostest" type="hztest" name="hough_circles_test" >

--- a/test/test-hough_lines.test
+++ b/test/test-hough_lines.test
@@ -18,8 +18,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="standard_hough_lines_saver" pkg="image_view" type="image_saver" args="image:=standard_hough_lines/image" >
+    <node name="standard_hough_lines_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/standard_hough_lines.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="standard_hough_lines/image" />
+      <remap from="standard_hough_lines/camera_info" to="camera_info" />
     </node>
     <param name="standard_hough_lines_test/topic" value="standard_hough_lines/lines" />    <!-- opencv_apps/LineArrayStamped -->
     <test test-name="standard_hough_lines_test" pkg="rostest" type="hztest" name="standard_hough_lines_test" >
@@ -38,8 +41,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="probabilistic_hough_lines_saver" pkg="image_view" type="image_saver" args="image:=probabilistic_hough_lines/image" >
+    <node name="probabilistic_hough_lines_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/probabilistic_hough_lines.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="probabilistic_hough_lines/image" />
+      <remap from="probabilistic_hough_lines/camera_info" to="camera_info" />
     </node>
     <param name="probabilistic_hough_lines_test/topic" value="probabilistic_hough_lines/lines" />    <!-- opencv_apps/LineArrayStamped -->
     <test test-name="probabilistic_hough_lines_test" pkg="rostest" type="hztest" name="probabilistic_hough_lines_test" >

--- a/test/test-hsv_color_filter.test
+++ b/test/test-hsv_color_filter.test
@@ -20,8 +20,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="hsv_color_filter_saver" pkg="image_view" type="image_saver" args="image:=hsv_color_filter/image" >
+    <node name="hsv_color_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/hsv_color_filter.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="hsv_color_filter/image" />
+      <remap from="hsv_color_filter/camera_info" to="camera_info" />
     </node>
     <param name="hsv_color_filter_test/topic" value="hsv_color_filter/image" />
     <test test-name="hsv_color_filter_test" pkg="rostest" type="hztest" name="hsv_color_filter_test" >

--- a/test/test-lab_color_filter.test
+++ b/test/test-lab_color_filter.test
@@ -20,8 +20,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="lab_color_filter_saver" pkg="image_view" type="image_saver" args="image:=lab_color_filter/image" >
+    <node name="lab_color_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/lab_color_filter.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="lab_color_filter/image" />
+      <remap from="lab_color_filter/camera_info" to="camera_info" />
     </node>
     <param name="lab_color_filter_test/topic" value="lab_color_filter/image" />
     <test test-name="lab_color_filter_test" pkg="rostest" type="hztest" name="lab_color_filter_test" >

--- a/test/test-lk_flow.test
+++ b/test/test-lk_flow.test
@@ -14,8 +14,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="lk_flow_saver" pkg="image_view" type="image_saver" args="image:=lk_flow/image" >
+    <node name="lk_flow_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/lk_flow.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="lk_flow/image" />
+      <remap from="lk_flow/camera_info" to="camera_info" />
     </node>
     <node name="lk_flow_initialize" pkg="rosservice" type="rosservice" args="call --wait lk_flow/initialize_points"
           respawn="true" respawn_delay="2" />

--- a/test/test-morphology.test
+++ b/test/test-morphology.test
@@ -19,8 +19,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="morphology_saver" pkg="image_view" type="image_saver" args="image:=morphology/image" >
+    <node name="morphology_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/morphology.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="morphology/image" />
+      <remap from="morphology/camera_info" to="camera_info" />
     </node>
     <param name="morphology_test/topic" value="morphology/image" />
     <test test-name="morphology_test" pkg="rostest" type="hztest" name="morphology_test" >

--- a/test/test-people_detect.test
+++ b/test/test-people_detect.test
@@ -14,8 +14,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="people_detect_saver" pkg="image_view" type="image_saver" args="image:=people_detect/image" >
+    <node name="people_detect_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/people_detect.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="people_detect/image" />
+      <remap from="people_detect/camera_info" to="camera_info" />
     </node>
     <param name="people_detect_test/topic" value="people_detect/found" />    <!-- opencv_apps/RectArrayStamped -->
     <test test-name="people_detect_test" pkg="rostest" type="hztest" name="people_detect_test" time-limit="120" >

--- a/test/test-phase_corr.test
+++ b/test/test-phase_corr.test
@@ -14,8 +14,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="phase_corr_saver" pkg="image_view" type="image_saver" args="image:=phase_corr/image" >
+    <node name="phase_corr_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/phase_corr.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="phase_corr/image" />
+      <remap from="phase_corr/camera_info" to="camera_info" />
     </node>
     <param name="phase_corr_test/topic" value="phase_corr/shift" />    <!-- opencv_apps/Point2DStamped -->
     <test test-name="phase_corr_test" pkg="rostest" type="hztest" name="phase_corr_test" >

--- a/test/test-pyramids.test
+++ b/test/test-pyramids.test
@@ -53,8 +53,11 @@
     </node>
 
     <!-- Test Codes -->
-    <node name="pyramids_saver_result" pkg="image_view" type="image_saver" args="image:=adding_images_2/image" >
+    <node name="pyramids_saver_result" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/pyramids_result.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="adding_images_2/image" />
+      <remap from="adding_images_2/camera_info" to="camera_info" />
     </node>
     <param name="pyramids_test/topic" value="pyramids_zoomin_1/image" />
     <test test-name="pyramids_test" pkg="rostest" type="hztest" name="pyramids_test" >

--- a/test/test-rgb_color_filter.test
+++ b/test/test-rgb_color_filter.test
@@ -20,8 +20,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="rgb_color_filter_saver" pkg="image_view" type="image_saver" args="image:=rgb_color_filter/image" >
+    <node name="rgb_color_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/rgb_color_filter.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="rgb_color_filter/image" />
+      <remap from="rgb_color_filter/camera_info" to="camera_info" />
     </node>
     <param name="rgb_color_filter_test/topic" value="rgb_color_filter/image" />
     <test test-name="rgb_color_filter_test" pkg="rostest" type="hztest" name="rgb_color_filter_test" >

--- a/test/test-segment_objects.test
+++ b/test/test-segment_objects.test
@@ -15,8 +15,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="segment_objects_saver" pkg="image_view" type="image_saver" args="image:=segment_objects/image" >
+    <node name="segment_objects_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/segment_objects.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="segment_objects/image" />
+      <remap from="segment_objects/camera_info" to="camera_info" />
     </node>
     <param name="segment_objects_test/topic" value="segment_objects/contours" />    <!-- opencv_apps/ContoruArrayStamped -->
     <test test-name="segment_objects_test" pkg="rostest" type="hztest" name="segment_objects_test" >

--- a/test/test-simple_example.test
+++ b/test/test-simple_example.test
@@ -5,7 +5,7 @@
 
   <group ns="narrow_stereo/left" >
     <node name="input" pkg="image_view" type="image_view" args="image:=image_rect" if="$(arg gui)" />
-    <node name="output" pkg="image_view" type="image_view" args="image:=/image_converter/output_video/raw" if="$(arg gui)" />
+    <node name="output" pkg="image_view" type="image_view" args="image:=/image_converter/output_video _image_transport:=raw" if="$(arg gui)" />
 
     <!-- simple_example.cpp -->
     <node name="simple_example" pkg="opencv_apps" type="simple_example" args="image:=image_rect" >
@@ -13,8 +13,12 @@
     </node>
 
     <!-- Testing -->
-    <node name="simple_example_saver" pkg="image_view" type="image_saver" args="image:=/image_converter/output_video/raw" >
+    <node name="simple_example_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/simple_example.png"/>
+      <param name="queue_size" value="5" />
+      <param name="image_transport" value="raw" />
+      <remap from="image" to="/image_converter/output_video" />
+      <remap from="/image_converter/output_video/camera_info" to="camera_info" />
     </node>
     <param name="simple_example_test/topic" value="/image_converter/output_video/raw" />
     <test test-name="simple_example_test" pkg="rostest" type="hztest" name="simple_example_test" retry="3" >

--- a/test/test-simple_flow.test
+++ b/test/test-simple_flow.test
@@ -1,7 +1,7 @@
 <launch>
   <arg name="gui" default="true" />
   <param name="use_sim_time" value="true" />
-  <node name="play_vslam_bag" pkg="rosbag" type="play" args="-l $(find opencv_apps)/test/vslam_tutorial.bag -s 5 -r 0.1 --topics /narrow_stereo/left/image_rect /clock" />
+  <node name="play_vslam_bag" pkg="rosbag" type="play" args="-l $(find opencv_apps)/test/vslam_tutorial.bag -s 5 -r 0.1 --topics /narrow_stereo/left/image_rect /narrow_stereo/left/camera_info /clock" />
 
   <group ns="narrow_stereo/left" >
     <node name="image_view" pkg="image_view" type="image_view" args="image:=image_rect" if="$(arg gui)" />
@@ -15,8 +15,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="simple_flow_saver" pkg="image_view" type="image_saver" args="image:=simple_flow/image" >
+    <node name="simple_flow_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/simple_flow.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="simple_flow/image" />
+      <remap from="simple_flow/camera_info" to="camera_info" />
     </node>
     <param name="simple_flow_test/topic" value="simple_flow/flows" />    <!-- opencv_apps/FlowArrayStamped -->
     <test test-name="simple_flow_test" pkg="rostest" type="hztest" name="simple_flow_test" >

--- a/test/test-smoothing.test
+++ b/test/test-smoothing.test
@@ -19,6 +19,7 @@
     <!-- Test Codes -->
     <node name="smooth_homogeneous_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_homogeneous_filter.png"/>
+      <param name="queue_size" value="5" />
       <remap from="image" to="smooth_homogeneous_filter/image" />
       <remap from="smooth_homogeneous_filter/camera_info" to="camera_info" />
     </node>
@@ -40,6 +41,7 @@
     <!-- Test Codes -->
     <node name="smooth_gaussian_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_gaussian_filter.png"/>
+      <param name="queue_size" value="5" />
       <remap from="image" to="smooth_gaussian_filter/image" />
       <remap from="smooth_gaussian_filter/camera_info" to="camera_info" />
     </node>
@@ -61,6 +63,7 @@
     <!-- Test Codes -->
     <node name="smooth_median_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_median_filter.png"/>
+      <param name="queue_size" value="5" />
       <remap from="image" to="smooth_median_filter/image" />
       <remap from="smooth_median_filter/camera_info" to="camera_info" />
     </node>
@@ -82,6 +85,7 @@
     <!-- Test Codes -->
     <node name="smooth_bilateral_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_bilateral_filter.png"/>
+      <param name="queue_size" value="5" />
       <remap from="image" to="smooth_bilateral_filter/image" />
       <remap from="smooth_bilateral_filter/camera_info" to="camera_info" />
     </node>

--- a/test/test-smoothing.test
+++ b/test/test-smoothing.test
@@ -17,8 +17,10 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="smooth_homogeneous_filter_saver" pkg="image_view" type="image_saver" args="image:=smooth_homogeneous_filter/image" >
+    <node name="smooth_homogeneous_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_homogeneous_filter.png"/>
+      <remap from="image" to="smooth_homogeneous_filter/image" />
+      <remap from="smooth_homogeneous_filter/camera_info" to="camera_info" />
     </node>
     <param name="smooth_homogeneous_filter_test/topic" value="smooth_homogeneous_filter/image" />    <!-- opencv_apps/FaceArrayStamped -->
     <test test-name="smooth_homogeneous_filter_test" pkg="rostest" type="hztest" name="smooth_homogeneous_filter_test" >
@@ -36,8 +38,10 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="smooth_gaussian_filter_saver" pkg="image_view" type="image_saver" args="image:=smooth_gaussian_filter/image" >
+    <node name="smooth_gaussian_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_gaussian_filter.png"/>
+      <remap from="image" to="smooth_gaussian_filter/image" />
+      <remap from="smooth_gaussian_filter/camera_info" to="camera_info" />
     </node>
     <param name="smooth_gaussian_filter_test/topic" value="smooth_gaussian_filter/image" />
     <test test-name="smooth_gaussian_filter_test" pkg="rostest" type="hztest" name="smooth_gaussian_filter_test" >
@@ -55,8 +59,10 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="smooth_median_filter_saver" pkg="image_view" type="image_saver" args="image:=smooth_median_filter/image" >
+    <node name="smooth_median_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_median_filter.png"/>
+      <remap from="image" to="smooth_median_filter/image" />
+      <remap from="smooth_median_filter/camera_info" to="camera_info" />
     </node>
     <param name="smooth_median_filter_test/topic" value="smooth_median_filter/image" />
     <test test-name="smooth_median_filter_test" pkg="rostest" type="hztest" name="smooth_median_filter_test" >
@@ -74,8 +80,10 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="smooth_bilateral_filter_saver" pkg="image_view" type="image_saver" args="image:=smooth_bilateral_filter/image" >
+    <node name="smooth_bilateral_filter_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/smooth_bilateral_filter.png"/>
+      <remap from="image" to="smooth_bilateral_filter/image" />
+      <remap from="smooth_bilateral_filter/camera_info" to="camera_info" />
     </node>
     <param name="smooth_bilateral_filter_test/topic" value="smooth_bilateral_filter/image" />
     <test test-name="smooth_bilateral_filter_test" pkg="rostest" type="hztest" name="smooth_bilateral_filter_test" >

--- a/test/test-threshold.test
+++ b/test/test-threshold.test
@@ -18,8 +18,11 @@
     </include>
 
     <!-- Test Codes -->
-    <node name="threshold_saver_result" pkg="image_view" type="image_saver" args="image:=threshold/image" >
+    <node name="threshold_saver_result" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/threshold_result.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="threshold/image" />
+      <remap from="threshold/camera_info" to="camera_info" />
     </node>
     <param name="threshold_test/topic" value="threshold/image" />
     <test test-name="threshold_test" pkg="rostest" type="hztest" name="threshold_test" >

--- a/test/test-watershed_segmentation.test
+++ b/test/test-watershed_segmentation.test
@@ -17,8 +17,11 @@
     <!-- Test Codes -->
     <node name="pub_add_seed_points" pkg="rostopic" type="rostopic"
             args="pub -r 1.5 watershed_segmentation/add_seed_points opencv_apps/Point2DArray '[{x: 100, y: 100},{x: 200, y: 100},{x: 300, y: 100},{x: 400, y: 100},{x: 500, y: 100},{x: 100, y: 200},{x: 200, y: 200},{x: 300, y: 200},{x: 400, y: 200},{x: 500, y: 200},{x: 100, y: 300},{x: 200, y: 300},{x: 300, y: 300},{x: 400, y: 300},{x: 500, y: 300}]' --" />
-    <node name="watershed_segmentation_saver" pkg="image_view" type="image_saver" args="image:=watershed_segmentation/image" >
+    <node name="watershed_segmentation_saver" pkg="image_view" type="image_saver" >
       <param name="filename_format" value="$(find opencv_apps)/test/watershed_segmentation.png"/>
+      <param name="queue_size" value="5" />
+      <remap from="image" to="watershed_segmentation/image" />
+      <remap from="watershed_segmentation/camera_info" to="camera_info" />
     </node>
     <param name="watershed_segmentation_test/topic" value="watershed_segmentation/contours" />    <!-- opencv_apps/ContourStamped -->
     <test test-name="watershed_segmentation_test" pkg="rostest" type="hztest" name="watershed_segmentation_test" >


### PR DESCRIPTION
properly remap camera_info, based on https://github.com/ros-perception/opencv_apps/pull/101/commits/2344878e67b6c2ac7c65a6897f27c3b5bf464424 (#101)

- 357f600 (Kei Okada, 16 minutes ago)
    add more  properly remap camera_info, to remove warning we need to set
    queue_size for image_saver (which take effects if
    https://github.com/ros-perception/image_pipeline/pull/731 merged)

- b618b7d (Kei Okada, 17 minutes ago)
    run rosbag fix for old vslam_tutorial.bag file

- bcbff98 (Martin Günther, 2 years, 3 months ago)
    tests: properly remap camera_info

    The image_saver nodes were subscribing to the wrong camera_info topic,
    which resulted in the following warnings during the tests:

    ```
    $ rostest opencv_apps test-smoothing.test gui:=false
    [ WARN] [1574169448.182609516]: [image_transport] Topics
    '/wide_stereo/left/smooth_homogeneous_filter/image' and
    '/wide_stereo/left/smooth_homogeneous_filter/camera_info' do not appear to
    be synchronized. In the last 10s:
    Image messages received:      181
    CameraInfo messages received: 0
    Synchronized pairs:           0
    (/wide_stereo/left/smooth_homogeneous_filter_saver)
    ```

    This warning probably only doesn't occur for the other tests because they
    run shorter; the remapping should be done for all other tests as well (but
    I'm too lazy).