### PR TITLE
check all output of test/test-pyramids.test

### DIFF
--- a/test/test-pyramids.test
+++ b/test/test-pyramids.test
@@ -34,21 +34,21 @@
       <remap from="image1" to="pyramids_zoomin_1/image" />
       <remap from="image2" to="image_rect_color" />
       <param name="alpha" value="0" />
-      <param name="debug_view" value="false" />
+      <param name="debug_view" value="$(arg gui)" />
       <param name="approximate_sync" value="true" />
     </node>
     <node name="adding_images_1" pkg="opencv_apps" type="adding_images" >
       <remap from="image1" to="adding_images_0/image" />
       <remap from="image2" to="pyramids_zoomout_1/image" />
       <param name="alpha" value="0" />
-      <param name="debug_view" value="false" />
+      <param name="debug_view" value="$(arg gui)" />
       <param name="approximate_sync" value="true" />
     </node>
     <node name="adding_images_2" pkg="opencv_apps" type="adding_images" >
       <remap from="image1" to="adding_images_1/image" />
       <remap from="image2" to="pyramids_zoomout_2/image" />
       <param name="alpha" value="0" />
-      <param name="debug_view" value="true" />
+      <param name="debug_view" value="$(arg gui)" />
       <param name="approximate_sync" value="true" />
     </node>
 

--- a/test/test-pyramids.test
+++ b/test/test-pyramids.test
@@ -59,11 +59,41 @@
       <remap from="image" to="adding_images_2/image" />
       <remap from="adding_images_2/camera_info" to="camera_info" />
     </node>
-    <param name="pyramids_test/topic" value="pyramids_zoomin_1/image" />
-    <test test-name="pyramids_test" pkg="rostest" type="hztest" name="pyramids_test" >
-      <param name="hz" value="30" />
-      <param name="hzerror" value="10.0" />
-      <param name="test_duration" value="1.0" />
+    <test test-name="adding_images_0_test" pkg="rostest" type="hztest" name="adding_images_0_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" />
+      <param name="topic" value="adding_images_0/image" />
+    </test>
+    <test test-name="adding_images_1_test" pkg="rostest" type="hztest" name="adding_images_1_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" />
+      <param name="topic" value="adding_images_1/image" />
+    </test>
+    <test test-name="adding_images_2_test" pkg="rostest" type="hztest" name="adding_images_2_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" />
+      <param name="topic" value="adding_images_2/image" />
+    </test>
+    <test test-name="pyramids_zoomin_1_test" pkg="rostest" type="hztest" name="pyramids_zoomin_1_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" />
+      <param name="topic" value="pyramids_zoomin_1/image" />
+    </test>
+    <test test-name="pyramids_zoomout_1_test" pkg="rostest" type="hztest" name="pyramids_zoomout_1_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" />
+      <param name="topic" value="pyramids_zoomout_1/image" />
+    </test>
+    <test test-name="pyramids_zoomout_2_test" pkg="rostest" type="hztest" name="pyramids_zoomout_2_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" />
+      <param name="topic" value="pyramids_zoomout_2/image" />
     </test>
   </group>
 </launch>


### PR DESCRIPTION
cherry-picked https://github.com/ros-perception/opencv_apps/pull/101/commits/cc70d81e77afd3ce61f2da5bbd03360b4947ab9b, https://github.com/ros-perception/opencv_apps/pull/101/commits/7a728890dcfed252358e877f42c158502354a219 (#101)

Closes #99

- f8e3fd0 (Martin Günther, 2 years, 3 months ago)
    test-pyramids: disable debug_view if gui=false

    adding_images_2 had the debug view always enabled, so it failed in docker.

- 24c6ab8 (Martin Günther, 2 years, 3 months ago)
    test-pyramids: Check all topics

    This test now correctly identifies the errors and fails (which is what we
    want):

    ```
    $ rostest opencv_apps test-pyramids.test gui:=false OpenCV Error: Sizes of
    input arguments do not match (The operation is neither 'array op array'
    (where arrays have the same size and the same number of channels), nor
    'array op scalar', nor 'scalar op array') in arithm_op, file
    /build/opencv-L2vuMj/opencv-3.2.0+dfsg/modules/core/src/arithm.cpp, line
    659
    [ERROR] [1574173610.416466509]: Image processing error: The operation is
    neither 'array op array' (where arrays have the same size and the same
    number of channels), nor 'array op scalar', nor 'scalar op array' arithm_op
    /build/opencv-L2vuMj/opencv-3.2.0+dfsg/modules/core/src/arithm.cpp 659
    (/wide_stereo/left/adding_images_0)

    ```