### PR TITLE
enlarge maximum morph size in cfg file.

### DIFF
--- a/cfg/Morphology.cfg
+++ b/cfg/Morphology.cfg
@@ -16,6 +16,6 @@ morph_operator = gen.enum([ gen.const("Opening",   int_t,  0, "Opening"),
 
 gen.add("morph_operator", int_t, 0, "Morphology Operation Methods", 1, 0, 3, edit_method=morph_operator)
 gen.add("morph_element", int_t, 0, "Type of the kernel 0: Rect, 1: Cross, 2: Ellipse", 0, 0, 2)
-gen.add("morph_size", int_t, 0, "Size of the kernel. Must be odd.", 0, 0, 21)
+gen.add("morph_size", int_t, 0, "Size of the kernel. Must be odd.", 0, 0, 101)
 
 exit (gen.generate (PACKAGE, "morphology", "Morphology"))


### PR DESCRIPTION
Previous maximum morph size in cfg file is 21, which is too small for many image process.
Therefore, we enlarge its value for more convenient usage.