### PR TITLE
Add sync_.reset/async_.reset to destructor in face_recognition

### DIFF
--- a/src/nodelet/face_recognition_nodelet.cpp
+++ b/src/nodelet/face_recognition_nodelet.cpp
@@ -650,7 +650,7 @@ class FaceRecognitionNodelet : public opencv_apps::Nodelet
   }
 
 public:
-  virtual ~FaceRecognitionNodelet()
+  ~FaceRecognitionNodelet()  // NOLINT(modernize-use-override)
   {
     sync_.reset();
     async_.reset();

--- a/src/nodelet/face_recognition_nodelet.cpp
+++ b/src/nodelet/face_recognition_nodelet.cpp
@@ -650,6 +650,11 @@ class FaceRecognitionNodelet : public opencv_apps::Nodelet
   }
 
 public:
+  virtual ~FaceRecognitionNodelet() {
+    sync_.reset();
+    async_.reset();
+  }
+
   virtual void onInit()  // NOLINT(modernize-use-override)
   {
     Nodelet::onInit();

--- a/src/nodelet/face_recognition_nodelet.cpp
+++ b/src/nodelet/face_recognition_nodelet.cpp
@@ -650,7 +650,8 @@ class FaceRecognitionNodelet : public opencv_apps::Nodelet
   }
 
 public:
-  virtual ~FaceRecognitionNodelet() {
+  virtual ~FaceRecognitionNodelet()
+  {
     sync_.reset();
     async_.reset();
   }


### PR DESCRIPTION
When the nodelet is killed,  the following error is raised.
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```
To delete `sync_` and `async_` before subscribers, we can reset SyncPolicy in `~FaceRecognitionNodelet()` or change the order of declaration.