### PR TITLE
[face_detection] Fix arg condition when launching with opencv4 in noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(opencv_apps)
 
 ## https://stackoverflow.com/questions/10984442/how-to-detect-c11-support-of-a-compiler-with-cmake

--- a/launch/face_detection.launch
+++ b/launch/face_detection.launch
@@ -13,26 +13,26 @@
   <arg name="queue_size" default="3" doc="Specigy queue_size of input image subscribers" />
 
   <arg if="$(arg use_opencv3_1)"
-       name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.1.0-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
+       name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.1.0-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv3_1)"
-       name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.1.0-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
+       name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.1.0-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
   <arg if="$(arg use_opencv3_2)"
-       name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.2.0-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
+       name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.2.0-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv3_2)"
-       name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.2.0-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
+       name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.2.0-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
   <arg if="$(arg use_opencv3_3)"
-       name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.3.1-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
+       name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.3.1-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv3_3)"
-       name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.3.1-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
+       name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.3.1-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
   <arg if="$(arg use_opencv4)"
-       name="face_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
+       name="face_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv4)"
-       name="eyes_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
+       name="eyes_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
 
   <arg if="$(arg use_opencv3)"
-       name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
+       name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv3)"
-       name="eyes_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
+       name="eyes_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
 
   <!-- face_detection.cpp -->
   <node name="$(arg node_name)" pkg="opencv_apps" type="face_detection"  >

--- a/launch/face_detection.launch
+++ b/launch/face_detection.launch
@@ -4,13 +4,19 @@
   <arg name="use_opencv3_1" default="false" />
   <arg name="use_opencv3_2" default="false" />
   <arg name="use_opencv3_3" default="false" />
-  <arg name="use_opencv4" default="false" />
+  <arg name="use_opencv4" default="true" />
 
   <arg name="image" default="image" doc="The image topic. Should be remapped to the name of the real image topic." />
 
   <arg name="use_camera_info" default="false" doc="Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used." />
   <arg name="debug_view" default="true" doc="Specify whether the node displays a window to show edge image" />
   <arg name="queue_size" default="3" doc="Specigy queue_size of input image subscribers" />
+
+
+  <arg if="$(eval use_opencv3==True and use_opencv4==False)"
+       name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
+  <arg if="$(eval use_opencv3==True and use_opencv4==False)"
+       name="eyes_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
 
   <arg if="$(arg use_opencv3_1)"
        name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.1.0-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
@@ -24,15 +30,12 @@
        name="face_cascade_name" default="$(find opencv3)/../OpenCV-3.3.1-dev/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv3_3)"
        name="eyes_cascade_name" default="$(find opencv3)/../OpenCV-3.3.1-dev/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
+
+
   <arg if="$(arg use_opencv4)"
        name="face_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
   <arg if="$(arg use_opencv4)"
        name="eyes_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
-
-  <arg if="$(arg use_opencv3)"
-       name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face detection cascade Filename" />
-  <arg if="$(arg use_opencv3)"
-       name="eyes_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye detection cascade Filename" />
 
   <!-- face_detection.cpp -->
   <node name="$(arg node_name)" pkg="opencv_apps" type="face_detection"  >

--- a/launch/face_detection.launch
+++ b/launch/face_detection.launch
@@ -3,7 +3,7 @@
   <arg name="use_opencv3" default="false" />
   <arg name="use_opencv3_1" default="false" />
   <arg name="use_opencv3_2" default="false" />
-  <arg name="use_opencv3_3" default="$(arg use_opencv3)" />
+  <arg name="use_opencv3_3" default="false" />
   <arg name="use_opencv4" default="false" />
 
   <arg name="image" default="image" doc="The image topic. Should be remapped to the name of the real image topic." />
@@ -29,9 +29,9 @@
   <arg if="$(arg use_opencv4)"
        name="eyes_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
 
-  <arg unless="$(arg use_opencv3)"
+  <arg if="$(arg use_opencv3)"
        name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
-  <arg unless="$(arg use_opencv3)"
+  <arg if="$(arg use_opencv3)"
        name="eyes_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
 
   <!-- face_detection.cpp -->

--- a/launch/face_recognition.launch
+++ b/launch/face_recognition.launch
@@ -2,7 +2,7 @@
   <arg name="launch_face_detection" default="true" />
   <arg name="launch_trainer" default="true" />
 
-  <arg name="use_opencv3" default="false" />
+  <arg name="use_opencv3" default="true" />
   <arg name="use_opencv3_1" default="false" />
   <arg name="use_opencv3_2" default="false" />
   <arg name="use_opencv3_3" default="false" />

--- a/test/test-face_detection.test
+++ b/test/test-face_detection.test
@@ -1,6 +1,6 @@
 <launch>
   <arg name="gui" default="true" />
-  <arg name="use_opencv3" default="false" />
+  <arg name="use_opencv3" default="true" />
   <arg name="use_opencv3_1" default="false" />
   <arg name="use_opencv3_2" default="false" />
   <arg name="use_opencv3_3" default="false" />

--- a/test/test-face_recognition.test
+++ b/test/test-face_recognition.test
@@ -1,6 +1,6 @@
 <launch>
   <arg name="gui" default="true" />
-  <arg name="use_opencv3" default="false" />
+  <arg name="use_opencv3" default="true" />
   <arg name="use_opencv3_1" default="false" />
   <arg name="use_opencv3_2" default="false" />
   <arg name="use_opencv3_3" default="false" />


### PR DESCRIPTION
On noetic with opencv4, the following error occurs because arg `face_cascade_name` declares twice.
```bash
$ roslaunch opencv_apps face_detection.launch use_opencv4:=true image:=/usb_cam/image_raw debug_view:=false 
... logging to /home/tsukamoto/.ros/log/816f6d2e-9c7e-11ed-a041-270d6101f3c5/roslaunch-tsukamoto-desktop-ryzen-471330.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

RLException: Invalid <arg> tag: arg 'face_cascade_name' has already been declared. 

Arg xml is <arg unless="$(arg use_opencv3)" name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename"/>
The traceback for the exception was written to the log file

```

I think I fixed it in this PR, but this may not be the best solution because it contains breaking changes.
So, could you tell me  if anyone have another solution?

And I also fixed typo.