### PR TITLE
[TEST] Fix catkin_lint version 1.6.18 to avoid `cmake_minimum_required` error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
         if: matrix.TEST == 'catkin_lint'
         run: |
           sudo apt-get install -y -q python3-pip
-          sudo pip3 install catkin_lint rosdep
+          # See https://github.com/ros-perception/opencv_apps/pull/143
+          # In catkin_lint > 1.6.18, cmake_minimum_required >= 2.8.12
+          sudo pip3 install catkin_lint==1.6.18 rosdep
           sudo rosdep init
           rosdep update
       - name: catkin_lint test


### PR DESCRIPTION
`catkin_lint` log

https://pipelines.actions.githubusercontent.com/serviceHosts/35664210-479f-470c-bc87-a03d72d76c68/_apis/pipelines/1/runs/200/signedlogcontent/9?urlExpires=2023-01-30T12%3A16%3A24.8058849Z&urlSigningMethod=HMACV1&urlSignature=xU8GWV6Z6%2FejBQiyVWKeuvsvAGV6ttcMTcPFbEUG6y4%3D

```
2023-01-30T08:52:57.4198937Z catkin_lint: downloading melodic package index from https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
2023-01-30T08:53:01.2309575Z catkin_lint: downloading package manifest for 'rosbag'
2023-01-30T08:53:01.2330823Z catkin_lint: downloading package manifest for 'class_loader'
2023-01-30T08:53:01.2343459Z catkin_lint: downloading package manifest for 'topic_tools'
2023-01-30T08:53:01.2360577Z catkin_lint: downloading package manifest for 'cv_bridge'
2023-01-30T08:53:01.2374630Z catkin_lint: downloading package manifest for 'message_generation'
2023-01-30T08:53:01.2386933Z catkin_lint: downloading package manifest for 'std_msgs'
2023-01-30T08:53:01.2399061Z catkin_lint: downloading package manifest for 'rostopic'
2023-01-30T08:53:01.2414540Z catkin_lint: downloading package manifest for 'compressed_image_transport'
2023-01-30T08:53:01.2427825Z catkin_lint: downloading package manifest for 'sensor_msgs'
2023-01-30T08:53:01.2442774Z catkin_lint: downloading package manifest for 'message_runtime'
2023-01-30T08:53:01.2457773Z catkin_lint: downloading package manifest for 'catkin'
2023-01-30T08:53:01.2481167Z catkin_lint: downloading package manifest for 'nodelet'
2023-01-30T08:53:01.2502855Z catkin_lint: downloading package manifest for 'image_transport'
2023-01-30T08:53:01.2520992Z catkin_lint: downloading package manifest for 'rosservice'
2023-01-30T08:53:01.2539382Z catkin_lint: downloading package manifest for 'dynamic_reconfigure'
2023-01-30T08:53:01.2559608Z catkin_lint: downloading package manifest for 'rostest'
2023-01-30T08:53:01.2579031Z catkin_lint: downloading package manifest for 'image_view'
2023-01-30T08:53:01.2606085Z catkin_lint: downloading package manifest for 'image_proc'
2023-01-30T08:53:01.2636792Z catkin_lint: downloading package manifest for 'roscpp'
2023-01-30T08:53:01.2664678Z catkin_lint: downloading package manifest for 'std_srvs'
2023-01-30T08:53:01.2682378Z catkin_lint: downloading package manifest for 'roslaunch'
2023-01-30T08:53:01.3018574Z catkin_lint: checked 1 packages and found 1 problems
2023-01-30T08:53:01.3018950Z opencv_apps: CMakeLists.txt(1): error: support for CMake versions older than 2.8.12 is deprecated
2023-01-30T08:53:01.3019775Z catkin_lint: option -W2 will show 136 additional notices
2023-01-30T08:53:01.3532046Z ##[error]Process completed with exit code 1.
2023-01-30T08:53:01.3593502Z Post job cleanup.
```