### PR TITLE
[ROS-O] Fix build error with Boost 1.83

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7")
   else ()
     message(FATAL_ERROR "C++11 needed. Therefore a gcc compiler with a version higher than 4.3 is needed.")
   endif()
-endif(CMAKE_COMPILER_IS_GNUCXX)
+endif()
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure message_generation image_transport nodelet roscpp sensor_msgs std_msgs std_srvs class_loader)
 

--- a/src/nodelet/face_recognition_nodelet.cpp
+++ b/src/nodelet/face_recognition_nodelet.cpp
@@ -89,17 +89,13 @@ namespace filesystem3
 namespace filesystem
 {
 #endif
-template <>
-path& path::append<typename path::iterator>(typename path::iterator lhs, typename path::iterator rhs,
-                                            const codecvt_type& cvt)
-{
-  for (; lhs != rhs; ++lhs)
-    *this /= *lhs;
-  return *this;
-}
 path user_expanded_path(const path& p)
 {
-  path::const_iterator it(p.begin());
+  if (p.size() < 2)
+    return p;
+
+  auto it = p.begin();
+  // Replace the tilda with the home directory
   std::string user_dir = (*it).string();
   if (user_dir.length() == 0 || user_dir[0] != '~')
     return p;
@@ -121,8 +117,15 @@ path user_expanded_path(const path& p)
       return p;
     homedir = pw->pw_dir;
   }
+
+  // Append the rest of path
   ret = path(std::string(homedir));
-  return ret.append(++it, p.end(), path::codecvt());
+  ++it;
+  for (; it != p.end(); ++it)
+  {
+    ret /= *it;
+  }
+  return ret;
 }
 }  // namespace filesystem
 }  // namespace boost


### PR DESCRIPTION
The `boost::filesystem::path::append` function defined in the `src/nodelet/face_recognition_nodelet.cpp` have conflict with the boost function.
In this PR, I removed the function and expanded the content to the only called place (in the `user_expanded_path` function).

In addition to that, I fixed the cmake warning:

```
Warnings   << opencv_apps:cmake /var/runner/catkin_ws/logs/opencv_apps/build.cmake.000.log                                                                                                             
CMake Warning (dev) in CMakeLists.txt:
  A logical block opening on the line

    /var/runner/catkin_ws/src/opencv_apps/CMakeLists.txt:5 (if)

  closes on the line

    /var/runner/catkin_ws/src/opencv_apps/CMakeLists.txt:16 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```